### PR TITLE
Add time dependence

### DIFF
--- a/HitScoreVisualizer/Harmony Patches/FlyingScoreEffectHandleSaberAfterCutSwingRatingCounterDidChangeEvent.cs
+++ b/HitScoreVisualizer/Harmony Patches/FlyingScoreEffectHandleSaberAfterCutSwingRatingCounterDidChangeEvent.cs
@@ -1,5 +1,6 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using HitScoreVisualizer.Services;
+using UnityEngine;
 
 namespace HitScoreVisualizer.Harmony_Patches
 {
@@ -20,7 +21,8 @@ namespace HitScoreVisualizer.Harmony_Patches
 			{
 				ScoreModel.RawScoreWithoutMultiplier(____noteCutInfo, out var before, out var after, out var accuracy);
 				var total = before + after + accuracy;
-				JudgmentService.Judge(__instance, total, before, after, accuracy);
+				var timeDependence = Mathf.Abs(____noteCutInfo.cutNormal.z);
+				JudgmentService.Judge(__instance, total, before, after, accuracy, timeDependence);
 			}
 
 			return false;

--- a/HitScoreVisualizer/Harmony Patches/FlyingScoreEffectInitAndPresent.cs
+++ b/HitScoreVisualizer/Harmony Patches/FlyingScoreEffectInitAndPresent.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using HitScoreVisualizer.Services;
 using IPA.Utilities;
 using UnityEngine;
@@ -54,7 +54,8 @@ namespace HitScoreVisualizer.Harmony_Patches
 			{
 				ScoreModel.RawScoreWithoutMultiplier(noteCutInfo, out var before, out var after, out var accuracy);
 				var total = before + after + accuracy;
-				JudgmentService.Judge(__instance, total, before, after, accuracy);
+				var timeDependence = Mathf.Abs(noteCutInfo.cutNormal.z);
+				JudgmentService.Judge(__instance, total, before, after, accuracy, timeDependence);
 
 				// If the counter is finished, remove our event from it
 				counter.didFinishEvent -= Judge;

--- a/HitScoreVisualizer/Services/ConfigProvider.cs
+++ b/HitScoreVisualizer/Services/ConfigProvider.cs
@@ -232,11 +232,13 @@ namespace HitScoreVisualizer.Services
 			// 99 is the max for NumberFormatInfo.NumberDecimalDigits
 			if (configuration.TimeDependenceDecimalPrecision < 0 || configuration.TimeDependenceDecimalPrecision > 99)
 			{
+				Plugin.LoggerInstance.Warn($"timeDependencyDecimalPrecision value {configuration.TimeDependenceDecimalPrecision} is outside the range of acceptable values [0, 99]");
 				return false;
 			}
 
 			if (configuration.TimeDependenceDecimalOffset < 0 || configuration.TimeDependenceDecimalOffset > Math.Log10(float.MaxValue))
 			{
+				Plugin.LoggerInstance.Warn($"timeDependencyDecimalOffset value {configuration.TimeDependenceDecimalOffset} is outside the range of acceptable values [0, {(int) Math.Log10(float.MaxValue)}]");
 				return false;
 			}
 

--- a/HitScoreVisualizer/Services/ConfigProvider.cs
+++ b/HitScoreVisualizer/Services/ConfigProvider.cs
@@ -229,6 +229,17 @@ namespace HitScoreVisualizer.Services
 				return false;
 			}
 
+			// 99 is the max for NumberFormatInfo.NumberDecimalDigits
+			if (configuration.TimeDependenceDecimalPrecision < 0 || configuration.TimeDependenceDecimalPrecision > 99)
+			{
+				return false;
+			}
+
+			if (configuration.TimeDependenceDecimalOffset < 0 || configuration.TimeDependenceDecimalOffset > Math.Log10(float.MaxValue))
+			{
+				return false;
+			}
+
 			if (configuration.BeforeCutAngleJudgments != null)
 			{
 				configuration.BeforeCutAngleJudgments = configuration.BeforeCutAngleJudgments.OrderByDescending(x => x.Threshold).ToList();

--- a/HitScoreVisualizer/Services/JudgmentService.cs
+++ b/HitScoreVisualizer/Services/JudgmentService.cs
@@ -86,7 +86,7 @@ namespace HitScoreVisualizer.Services
 						formattedBuilder.Append(after);
 						break;
 					case 't':
-						formattedBuilder.Append(ConvertTimeDependencePrecision(timeDependence));
+						formattedBuilder.Append(ConvertTimeDependencePrecision(timeDependence, instance.TimeDependenceDecimalOffset, instance.TimeDependenceDecimalPrecision));
 						break;
 					case 'B':
 						formattedBuilder.Append(JudgeSegment(before, instance.BeforeCutAngleJudgments));
@@ -160,18 +160,8 @@ namespace HitScoreVisualizer.Services
 			return string.Empty;
 		}
 
-		private static string ConvertTimeDependencePrecision(float timeDependence)
+		private static string ConvertTimeDependencePrecision(float timeDependence, int decimalOffset, int decimalPrecision)
 		{
-			var instance = ConfigProvider.CurrentConfig;
-			var decimalOffset = 1;
-			var decimalPrecision = 2;
-			if (instance != null)
-			{
-				decimalOffset = instance.timeDependenceDecimalOffset;
-				decimalPrecision = instance.timeDependenceDecimalPrecision;
-
-			}
-
 			var multiplier = Mathf.Pow(10, decimalOffset);
 			return (timeDependence * multiplier).ToString($"n{decimalPrecision}");
 		}

--- a/HitScoreVisualizer/Settings/Configuration.cs
+++ b/HitScoreVisualizer/Settings/Configuration.cs
@@ -16,6 +16,8 @@ namespace HitScoreVisualizer.Settings
 			DisplayMode = "format",
 			UseFixedPos = false,
 			DoIntermediateUpdates = true,
+			TimeDependenceDecimalPrecision = 1,
+			TimeDependenceDecimalOffset = 2,
 			Judgments = new List<Judgment>
 			{
 				new Judgment {Threshold = 115, Text = "%BFantastic%A%n%s", Color = new List<float> {1.0f, 1.0f, 1.0f, 1.0f}},
@@ -109,12 +111,12 @@ namespace HitScoreVisualizer.Settings
 		// Number of decimal places to show time dependence to
 		[JsonProperty("timeDependencyDecimalPrecision")]
 		[DefaultValue(1)]
-		public int timeDependenceDecimalPrecision { get; set; }
+		public int TimeDependenceDecimalPrecision { get; set; }
 
 		// Which power of 10 to multiply the time dependence by
 		[JsonProperty("timeDependencyDecimalOffset")]
 		[DefaultValue(2)]
-		public int timeDependenceDecimalOffset { get; set; }
+		public int TimeDependenceDecimalOffset { get; set; }
 
 		// Order from highest threshold to lowest; the first matching judgment will be applied
 		[JsonProperty("judgments")]

--- a/HitScoreVisualizer/Settings/Configuration.cs
+++ b/HitScoreVisualizer/Settings/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel;
 using Newtonsoft.Json;
 using UnityEngine;
@@ -65,7 +65,8 @@ namespace HitScoreVisualizer.Settings
 		// - %b: The score contributed by the part of the swing before cutting the block.
 		// - %c: The score contributed by the accuracy of the cut.
 		// - %a: The score contributed by the part of the swing after cutting the block.
-		// - %B, %C, %A: As above, except using the appropriate judgment from that part of the swing (as configured for "beforeCutAngleJudgments", "accuracyJudgments", or "afterCutAngleJudgments").
+		// - %t: The time dependence of the swing
+		// - %B, %C, %A, %T: As above, except using the appropriate judgment from that part of the swing (as configured for "beforeCutAngleJudgments", "accuracyJudgments", "afterCutAngleJudgments", or "timeDependencyJudgments").
 		// - %s: The total score for the cut.
 		// - %p: The percent out of 115 you achieved with your swing's score
 		// - %%: A literal percent symbol.
@@ -105,6 +106,16 @@ namespace HitScoreVisualizer.Settings
 		[JsonProperty("doIntermediateUpdates")]
 		public bool DoIntermediateUpdates { get; set; }
 
+		// Number of decimal places to show time dependence to
+		[JsonProperty("timeDependencyDecimalPrecision")]
+		[DefaultValue(1)]
+		public int timeDependenceDecimalPrecision { get; set; }
+
+		// Which power of 10 to multiply the time dependence by
+		[JsonProperty("timeDependencyDecimalOffset")]
+		[DefaultValue(2)]
+		public int timeDependenceDecimalOffset { get; set; }
+
 		// Order from highest threshold to lowest; the first matching judgment will be applied
 		[JsonProperty("judgments")]
 		public List<Judgment>? Judgments { get; set; }
@@ -124,5 +135,10 @@ namespace HitScoreVisualizer.Settings
 		// Format specifier: %A
 		[JsonProperty("afterCutAngleJudgments")]
 		public List<JudgmentSegment>? AfterCutAngleJudgments { get; set; }
+
+		// Judgments for time dependence (score is from 0-1).
+		// Format specifier: %T
+		[JsonProperty("timeDependencyJudgments")]
+		public List<TimeDependenceJudgmentSegment>? TimeDependenceJudgments { get; set; }
 	}
 }

--- a/HitScoreVisualizer/Settings/TimeDependenceJudgmentSegment.cs
+++ b/HitScoreVisualizer/Settings/TimeDependenceJudgmentSegment.cs
@@ -1,0 +1,19 @@
+using Newtonsoft.Json;
+
+namespace HitScoreVisualizer.Settings
+{
+	internal class TimeDependenceJudgmentSegment
+	{
+		[JsonIgnore]
+		internal static TimeDependenceJudgmentSegment Default { get; } = new TimeDependenceJudgmentSegment { Threshold = 0, Text = string.Empty };
+
+		// This judgment will be applied only when the time dependence >= this number.
+		// If no judgment can be applied, the judgment for this segment will be "" (the empty string).
+		[JsonProperty("threshold")]
+		public float Threshold { get; set; }
+
+		// The text to replace the appropriate judgment specifier with (%T) when this judgment applies.
+		[JsonProperty("text")]
+		public string? Text { get; set; }
+	}
+}

--- a/README.md
+++ b/README.md
@@ -62,14 +62,17 @@ You can use that file as a starting point in case you want to customize it. Just
 | useFixedPos | Whether or not to display the hit scores on a fixed position. When enabled, this will also hide the previous score if a new one appears. | true or false |
 | fixedPosX<br>fixedPosY<br>fixedPosZ| The coordinate where the hit scores should be shown when `useFixedPos` is set to `true` | floats |
 | doIntermediateUpdates | When enabled, Judgments will be updated multiple times. This will make score popups more accurate during a brief period before the note's score is finalized, at some cost of performance. | true or false |
+| timeDependencyDecimalPrecision | The number of decimal places to show the time dependence to.<br> **Must be between 0 and 99, inclusive** | ints |
+| timeDependencyDecimalOffset | Which power of 10 to multiply the time dependence by (time dependence is from 0 - 1).<br> **Must be between 0 and 38, inclusive**  | ints |
 | Judgments | The list of Judgments that can be used to customize the Judgments in general.  | Uses Judgment objects.<br>More info below. |
 | beforeCutAngleJudgments | The list that can be used to customize the Judgments for the part of the swing before cutting the block (score is from 0 - 70).<br>Format token: %B<br>* Can only be used when `displayMode` is set to `"format"` | Uses JudgmentSegments objects.<br>More info below. |
 | accuracyJudgments | The list that can be used to customize the Judgments for the accuracy of the cut. How close was the cut to the center of the block? (score is from 0 - 15).<br>Format token: %C<br>* Can only be used when `displayMode` is set to `"format"` | Uses JudgmentSegments objects.<br>More info below. |
 | afterCutAngleJudgments | The list that can be used to customize the Judgments for the part of the swing after cutting the block (score is from 0 - 30).<br>Format token: %A<br>* Can only be used when `displayMode` is set to `"format"` | Uses JudgmentSegments.<br>More info below. |
+| timeDependencyJudgments | The list that can be used to customize the Judgments for the time dependence (value is from 0 - 1).<br>Format token: %T<br>* Can only be used when `displayMode` is set to `"format"` | Uses TimeDependenceJudgmentSegments.<br>More info below. |
 
 
 ### Important info
-- The `text` property of both Judgment and JudgmentSegment also has support for [TextMeshPro formatting!](http://digitalnativestudios.com/textmeshpro/docs/rich-text/).
+- The `text` property of Judgment, JudgmentSegment, and TimeDependenceJudgmentSegment all have support for [TextMeshPro formatting!](http://digitalnativestudios.com/textmeshpro/docs/rich-text/).
 - The order of Judgments and JudgmentSegments in the list doesn't matter anymore from version 3.0.0 and onwards. However, it's still advised to keep a descending order if you plan on targetting older versions of HSV as well.
 - To prevent unexpected issues down the road, the validation will also check within each list whether there are Judgments or JudgmentSegments that share a threshold. Validation will mark the config is failed if when this is detected.
 
@@ -92,6 +95,14 @@ You can use that file as a starting point in case you want to customize it. Just
 | text | The text to display.<br>Remark: Format tokens can't be used in this text... or better, they can be used, but won't be replaced with the actual value. | "+++" |
 
 
+### TimeDependenceJudgmentSegments explanation
+
+| Property name(s) | Explanation / Info | Example or possible values |
+| --- | --- | --- |
+| threshold | The threshold that defines whether this TimeDependenceJudgmentSegment will be used for a given time dependence. The TimeDependenceJudgmentSegment will be used if it is the one with the highest threshold that's either equal or smaller than the given time dependence. It can also be omitted when it's the TimeDependenceJudgmentSegment for the lowest time dependences. | floats |
+| text | The text to display.<br>Remark: Format tokens can't be used in this text... or better, they can be used, but won't be replaced with the actual value. | "+++" |
+
+
 ### Format tokens
 
 | Token | Explanation / Info |
@@ -99,7 +110,8 @@ You can use that file as a starting point in case you want to customize it. Just
 | %b | The score contributed by the swing before cutting the block. |
 | %c | The score contributed by the accuracy of the cut. |
 | %a | The score contributed by the part of the swing after cutting the block. |
-| %B, %C, %A | Uses the Judgment text that matches the threshold as specified in either `beforeCutAngleJudgments`, `accuracyJudgments` or `afterCutAngleJudgments` (depending on the used token). |
+| %t | The time dependence of the swing. This value indicates how depedent the accuracy part of the score is upon *when* you hit the block, measured from 0 - 1. A value of 0 indicates a completely time independent swing, while a value of 1 indicates that the accuracy part of the score would vary greatly if the block was hit even slightly earlier or later.
+| %B, %C, %A, %T | Uses the Judgment text that matches the threshold as specified in either `beforeCutAngleJudgments`, `accuracyJudgments`, `afterCutAngleJudgments`, or `timeDependencyJudgments` (depending on the used token). |
 | %s | The total score of the cut. |
 | %% | A literal percent symbol. |
 | %n | A newline. |


### PR DESCRIPTION
A couple of notes

* Config property names use "timeDependency" instead of "timeDependence"  prefix as that's what the old version used, so this supports legacy configs. If it bothers you, I'm happy to look into supporting both names or changing the code to match the "timeDependency" naming scheme (though I prefer timeDependence 😛 )

* There's some code redundancy added here as time dependence judgments are only slightly different from the previous judgments (float instead of int). I don't know C# very well, so I couldn't figure out how to get this done via a template/generic instead 😔. An alternative might be to have both of these implement an interface or abstract class instead? Again, not too familiar with C#.

* I'm happy to write the necessary parts of the README for this, if you even want to include it there seeing as most users won't even know what TD is.