### PR TITLE
Stopgap improvements

### DIFF
--- a/HitScoreVisualizer/HarmonyPatches/FlyingScoreEffectPatch.cs
+++ b/HitScoreVisualizer/HarmonyPatches/FlyingScoreEffectPatch.cs
@@ -56,7 +56,7 @@ namespace HitScoreVisualizer.HarmonyPatches
 				__instance._maxCutDistanceScoreIndicator.enabled = false;
 
 				// Apply judgments a total of twice - once when the effect is created, once when it finishes.
-				Judge(__instance, (CutScoreBuffer) cutScoreBuffer, 30);
+				Judge(__instance, (CutScoreBuffer)cutScoreBuffer);
 			}
 
 			__instance.InitAndPresent(duration, targetPos, noteCutInfo.worldRotation, false);
@@ -105,14 +105,9 @@ namespace HitScoreVisualizer.HarmonyPatches
 			}
 		}
 
-		private void Judge(FlyingScoreEffect flyingScoreEffect, CutScoreBuffer cutScoreBuffer, int? assumedAfterCutScore = null)
+		private void Judge(FlyingScoreEffect flyingScoreEffect, CutScoreBuffer cutScoreBuffer)
 		{
-			var before = cutScoreBuffer.beforeCutScore;
-			var after = assumedAfterCutScore ?? cutScoreBuffer.afterCutScore;
-			var accuracy = cutScoreBuffer.centerDistanceCutScore;
-			var total = before + after + accuracy;
-			var timeDependence = Mathf.Abs(cutScoreBuffer.noteCutInfo.cutNormal.z);
-			_judgmentService.Judge(cutScoreBuffer.noteScoreDefinition, ref flyingScoreEffect._text, ref flyingScoreEffect._color, total, before, after, accuracy, timeDependence);
+			_judgmentService.Judge(ref flyingScoreEffect._text, ref flyingScoreEffect._color, cutScoreBuffer);
 		}
 	}
 }

--- a/HitScoreVisualizer/HitScoreVisualizer.csproj
+++ b/HitScoreVisualizer/HitScoreVisualizer.csproj
@@ -13,80 +13,60 @@
   <ItemGroup>
     <Reference Include="DataModels">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\DataModels.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Unity.TextMeshPro">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Main" Publicize="true">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="BeatmapCore">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
-      <Private>false</Private>
     </Reference>
     <Reference Include="GameplayCore">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="BGLib.UnityExtension">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.UnityExtension.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="HMLib">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="HMUI">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="IPA.Loader">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="0Harmony">
       <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Hive.Versioning">
       <HintPath>$(BeatSaberDir)\Libs\Hive.Versioning.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(BeatSaberDir)\Libs\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="BSML">
       <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Zenject">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject.dll</HintPath>
-      <Private>false</Private>
     </Reference>
     <Reference Include="Zenject-usage">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject-usage.dll</HintPath>
-      <Private>false</Private>
     </Reference>
     <Reference Include="SiraUtil">
       <HintPath>$(BeatSaberDir)\Plugins\SiraUtil.dll</HintPath>
-      <Private>false</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/HitScoreVisualizer/Services/ConfigProvider.cs
+++ b/HitScoreVisualizer/Services/ConfigProvider.cs
@@ -368,15 +368,15 @@ namespace HitScoreVisualizer.Services
 		private bool ValidateJudgments(Configuration configuration, string configName)
 		{
 			configuration.Judgments = configuration.Judgments!.OrderByDescending(x => x.Threshold).ToList();
-			var prevJudgement = configuration.Judgments.First();
-			if (prevJudgement.Fade)
+			var prevJudgment = configuration.Judgments.First();
+			if (prevJudgment.Fade)
 			{
-				prevJudgement.Fade = false;
+				prevJudgment.Fade = false;
 			}
 
-			if (!ValidateJudgmentColor(prevJudgement, configName))
+			if (!ValidateJudgmentColor(prevJudgment, configName))
 			{
-				_siraLog.Warn($"Judgment entry for threshold {prevJudgement.Threshold} has invalid color in {configName}");
+				_siraLog.Warn($"Judgment entry for threshold {prevJudgment.Threshold} has invalid color in {configName}");
 				return false;
 			}
 
@@ -384,20 +384,20 @@ namespace HitScoreVisualizer.Services
 			{
 				for (var i = 1; i < configuration.Judgments.Count; i++)
 				{
-					var currentJudgement = configuration.Judgments[i];
-					if (prevJudgement.Threshold != currentJudgement.Threshold)
+					var currentJudgment = configuration.Judgments[i];
+					if (prevJudgment.Threshold != currentJudgment.Threshold)
 					{
-						if (!ValidateJudgmentColor(currentJudgement, configName))
+						if (!ValidateJudgmentColor(currentJudgment, configName))
 						{
-							_siraLog.Warn($"Judgment entry for threshold {currentJudgement.Threshold} has invalid color in {configName}");
+							_siraLog.Warn($"Judgment entry for threshold {currentJudgment.Threshold} has invalid color in {configName}");
 							return false;
 						}
 
-						prevJudgement = currentJudgement;
+						prevJudgment = currentJudgment;
 						continue;
 					}
 
-					_siraLog.Warn($"Duplicate entry found for threshold {currentJudgement.Threshold} in {configName}");
+					_siraLog.Warn($"Duplicate entry found for threshold {currentJudgment.Threshold} in {configName}");
 					return false;
 				}
 			}
@@ -429,17 +429,17 @@ namespace HitScoreVisualizer.Services
 				return true;
 			}
 
-			var prevJudgementSegment = segments.First();
+			var prevJudgmentSegment = segments.First();
 			for (var i = 1; i < segments.Count; i++)
 			{
-				var currentJudgement = segments[i];
-				if (prevJudgementSegment.Threshold != currentJudgement.Threshold)
+				var currentJudgment = segments[i];
+				if (prevJudgmentSegment.Threshold != currentJudgment.Threshold)
 				{
-					prevJudgementSegment = currentJudgement;
+					prevJudgmentSegment = currentJudgment;
 					continue;
 				}
 
-				_siraLog.Warn($"Duplicate entry found for threshold {currentJudgement.Threshold} in {configName}");
+				_siraLog.Warn($"Duplicate entry found for threshold {currentJudgment.Threshold} in {configName}");
 				return false;
 			}
 
@@ -453,17 +453,17 @@ namespace HitScoreVisualizer.Services
 				return true;
 			}
 
-			var prevJudgementSegment = segments.First();
+			var prevJudgmentSegment = segments.First();
 			for (var i = 1; i < segments.Count; i++)
 			{
-				var currentJudgement = segments[i];
-				if (prevJudgementSegment.Threshold - currentJudgement.Threshold > double.Epsilon)
+				var currentJudgment = segments[i];
+				if (prevJudgmentSegment.Threshold - currentJudgment.Threshold > double.Epsilon)
 				{
-					prevJudgementSegment = currentJudgement;
+					prevJudgmentSegment = currentJudgment;
 					continue;
 				}
 
-				_siraLog.Warn($"Duplicate entry found for threshold {currentJudgement.Threshold} in {configName}");
+				_siraLog.Warn($"Duplicate entry found for threshold {currentJudgment.Threshold} in {configName}");
 				return false;
 			}
 

--- a/HitScoreVisualizer/Services/JudgmentService.cs
+++ b/HitScoreVisualizer/Services/JudgmentService.cs
@@ -16,7 +16,7 @@ namespace HitScoreVisualizer.Services
 			_configProvider = configProvider;
 		}
 
-		internal void Judge(IReadonlyCutScoreBuffer cutScoreBuffer, ref TextMeshPro text, ref Color color)
+		internal void Judge(ref TextMeshPro text, ref Color color, CutScoreBuffer cutScoreBuffer)
 		{
 			var config = _configProvider.GetCurrentConfig();
 			if (config == null)

--- a/HitScoreVisualizer/Services/JudgmentService.cs
+++ b/HitScoreVisualizer/Services/JudgmentService.cs
@@ -33,47 +33,47 @@ namespace HitScoreVisualizer.Services
 			text.overflowMode = TextOverflowModes.Overflow;
 
 			// save in case we need to fade
-			var index = config.Judgements!.FindIndex(j => j.Threshold <= cutScoreBuffer.cutScore);
-			var judgement = index >= 0 ? config.Judgements[index] : Judgement.Default;
+			var index = config.Judgments!.FindIndex(j => j.Threshold <= cutScoreBuffer.cutScore);
+			var judgment = index >= 0 ? config.Judgments[index] : Judgment.Default;
 
-			if (judgement.Fade)
+			if (judgment.Fade)
 			{
-				var fadeJudgement = config.Judgements[index - 1];
-				var baseColor = judgement.Color.ToColor();
-				var fadeColor = fadeJudgement.Color.ToColor();
-				var lerpDistance = Mathf.InverseLerp(judgement.Threshold, fadeJudgement.Threshold, cutScoreBuffer.cutScore);
+				var fadeJudgment = config.Judgments[index - 1];
+				var baseColor = judgment.Color.ToColor();
+				var fadeColor = fadeJudgment.Color.ToColor();
+				var lerpDistance = Mathf.InverseLerp(judgment.Threshold, fadeJudgment.Threshold, cutScoreBuffer.cutScore);
 				color = Color.Lerp(baseColor, fadeColor, lerpDistance);
 			}
 			else
 			{
-				color = judgement.Color.ToColor();
+				color = judgment.Color.ToColor();
 			}
 
 			text.text = config.DisplayMode switch
 			{
-				"format" => DisplayModeFormat(cutScoreBuffer, judgement, config),
-				"textOnly" => judgement.Text,
+				"format" => DisplayModeFormat(cutScoreBuffer, judgment, config),
+				"textOnly" => judgment.Text,
 				"numeric" => cutScoreBuffer.cutScore.ToString(),
-				"scoreOnTop" => $"{cutScoreBuffer.cutScore}\n{judgement.Text}\n",
-				_ => $"{judgement.Text}\n{cutScoreBuffer.cutScore}\n"
+				"scoreOnTop" => $"{cutScoreBuffer.cutScore}\n{judgment.Text}\n",
+				_ => $"{judgment.Text}\n{cutScoreBuffer.cutScore}\n"
 			};
 		}
 
 		// ReSharper disable once CognitiveComplexity
-		private static string DisplayModeFormat(IReadonlyCutScoreBuffer cutScoreBuffer, Judgement judgement, Configuration instance)
+		private static string DisplayModeFormat(IReadonlyCutScoreBuffer cutScoreBuffer, Judgment judgment, Configuration instance)
 		{
 			return cutScoreBuffer.noteCutInfo.noteData.gameplayType switch
 			{
-				NoteData.GameplayType.Normal => NormalNoteJudgement(cutScoreBuffer, judgement, instance),
+				NoteData.GameplayType.Normal => NormalNoteJudgment(cutScoreBuffer, judgment, instance),
 				NoteData.GameplayType.BurstSliderElement => string.Empty,
 				_ => cutScoreBuffer.cutScore.ToString(),
 			};
 		}
 
-		private static string NormalNoteJudgement(IReadonlyCutScoreBuffer cutScoreBuffer, Judgement judgement, Configuration instance)
+		private static string NormalNoteJudgment(IReadonlyCutScoreBuffer cutScoreBuffer, Judgment judgment, Configuration instance)
 		{
 			var formattedBuilder = new StringBuilder();
-			var formatString = judgement.Text;
+			var formatString = judgment.Text;
 			var nextPercentIndex = formatString.IndexOf('%');
 
 			var timeDependence = Mathf.Abs(cutScoreBuffer.noteCutInfo.cutNormal.z);
@@ -103,16 +103,16 @@ namespace HitScoreVisualizer.Services
 						formattedBuilder.Append(ConvertTimeDependencePrecision(timeDependence, instance.TimeDependenceDecimalOffset, instance.TimeDependenceDecimalPrecision));
 						break;
 					case 'B':
-						formattedBuilder.Append(JudgeSegment(cutScoreBuffer.beforeCutScore, instance.BeforeCutAngleJudgements));
+						formattedBuilder.Append(JudgeSegment(cutScoreBuffer.beforeCutScore, instance.BeforeCutAngleJudgments));
 						break;
 					case 'C':
-						formattedBuilder.Append(JudgeSegment(cutScoreBuffer.centerDistanceCutScore, instance.AccuracyJudgements));
+						formattedBuilder.Append(JudgeSegment(cutScoreBuffer.centerDistanceCutScore, instance.AccuracyJudgments));
 						break;
 					case 'A':
-						formattedBuilder.Append(JudgeSegment(cutScoreBuffer.afterCutScore, instance.AfterCutAngleJudgements));
+						formattedBuilder.Append(JudgeSegment(cutScoreBuffer.afterCutScore, instance.AfterCutAngleJudgments));
 						break;
 					case 'T':
-						formattedBuilder.Append(JudgeTimeDependenceSegment(timeDependence, instance.TimeDependenceJudgements, instance));
+						formattedBuilder.Append(JudgeTimeDependenceSegment(timeDependence, instance.TimeDependenceJudgments, instance));
 						break;
 					case 's':
 						formattedBuilder.Append(cutScoreBuffer.cutScore);
@@ -138,14 +138,14 @@ namespace HitScoreVisualizer.Services
 			return formattedBuilder.Append(formatString).ToString();
 		}
 
-		private static string JudgeSegment(int scoreForSegment, IList<JudgementSegment>? judgements)
+		private static string JudgeSegment(int scoreForSegment, IList<JudgmentSegment>? judgments)
 		{
-			if (judgements == null)
+			if (judgments == null)
 			{
 				return string.Empty;
 			}
 
-			foreach (var j in judgements)
+			foreach (var j in judgments)
 			{
 				if (scoreForSegment >= j.Threshold)
 				{
@@ -156,14 +156,14 @@ namespace HitScoreVisualizer.Services
 			return string.Empty;
 		}
 
-		private static string JudgeTimeDependenceSegment(float scoreForSegment, IList<TimeDependenceJudgementSegment>? judgements, Configuration instance)
+		private static string JudgeTimeDependenceSegment(float scoreForSegment, IList<TimeDependenceJudgmentSegment>? judgments, Configuration instance)
 		{
-			if (judgements == null)
+			if (judgments == null)
 			{
 				return string.Empty;
 			}
 
-			foreach (var j in judgements)
+			foreach (var j in judgments)
 			{
 				if (scoreForSegment >= j.Threshold)
 				{
@@ -174,15 +174,15 @@ namespace HitScoreVisualizer.Services
 			return string.Empty;
 		}
 
-		private static string FormatTimeDependenceSegment(TimeDependenceJudgementSegment? judgement, float timeDependence, Configuration instance)
+		private static string FormatTimeDependenceSegment(TimeDependenceJudgmentSegment? judgment, float timeDependence, Configuration instance)
 		{
-			if (judgement == null)
+			if (judgment == null)
 			{
 				return string.Empty;
 			}
 
 			var formattedBuilder = new StringBuilder();
-			var formatString = judgement.Text ?? string.Empty;
+			var formatString = judgment.Text ?? string.Empty;
 			var nextPercentIndex = formatString.IndexOf('%');
 			while (nextPercentIndex != -1)
 			{

--- a/HitScoreVisualizer/Settings/Judgment.cs
+++ b/HitScoreVisualizer/Settings/Judgment.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace HitScoreVisualizer.Settings


### PR DESCRIPTION
`ScoringType` seems to be a misleading type, whereas `GameplayType` lets us easily distinguish what kind of score we can expect a note to give. This fixes chain segments with an arc attached to it showing a score, for instance, and we can also now consistently show score for notes with arcs correctly.

I will be working on a way for chain heads to be represented in the near future.