### PR TITLE
New Features

### DIFF
--- a/HitScoreVisualizer/Config-Documentation.md
+++ b/HitScoreVisualizer/Config-Documentation.md
@@ -1,0 +1,101 @@
+## HitScoreVisualizer config documentation
+
+Below is a series of descriptions that relate to each value in a HitScoreVisualizer json config
+
+### "majorVersion" "minorVersion" "patchVersion"
+If the version number (excluding patch version) of the config is higher than that of the plugin, the config will not be loaded. If the version number of the config is lower than that of the plugin, the file will be automatically converted. Conversion is not guaranteed to occur, or be accurate, across major versions
+
+### "isDefaultConfig"
+If this is true, the config will be overwritten with the plugin' default settings after an update rather than being converted
+
+### "displayMode"
+If set to "format", displays the judgment text, with the following format specifiers allowed:
+- %b: The score contributed by the part of the swing before cutting the block
+- %c: The score contributed by the accuracy of the cut
+- %a: The score contributed by the part of the swing after cutting the block
+- %t: The time dependence of the swing
+- %B, %C, %A, %T: As above, except using the appropriate judgment from that part of the swing (as configured for "beforeCutAngleJudgments", "accuracyJudgments", "afterCutAngleJudgments", or "timeDependencyJudgments")
+- %s: The total score for the cut
+- %p: The percent out of 115 you achieved with your swing's score
+- %%: A literal percent symbol
+- %n: A newline
+
+If set to "numeric", displays only the note score. If set to "textOnly", displays only the judgment text. If set to "scoreOnTop", displays both (numeric score above judgment text). Otherwise, displays both (judgment text above numeric score)
+
+### "fixedPosition"
+If not null, judgments will appear and stay at rather than moving as normal, this will take priority over TargetPositionOffset. Additionally, the previous judgment will disappear when a new one is created (so there won't be overlap)
+
+### "targetPositionOffset"
+Will offset the target position of the hitscore fade animation. If a fixed position is defined in the config, that one will take priority over this one and this will be fully ignored
+
+### "timeDependencyDecimalPrecision"
+Number of decimal places to show time dependence to
+
+### "timeDependencyDecimalOffset"
+Which power of 10 to multiply the time dependence by
+
+### "judgments"
+Order from highest threshold to lowest; the first matching judgment will be applied
+
+### "chainHeadJudgments"
+Same as normal judgments but for burst sliders aka. chain notes
+
+### "chainLinkDisplay"
+Text displayed for burst slider segments
+
+### "beforeCutAngleJudgments"
+Judgments for the part of the swing before cutting the block (score is from 0-70)
+
+### "accuracyJudgments"
+Judgments for the accuracy of the cut (how close to the center of the block the cut was, score is from 0-15)
+
+### "afterCutAngleJudgments"
+Judgments for the part of the swing after cutting the block (score is from 0-30)
+
+### "timeDependencyJudgments"
+Judgments for time dependence (score is from 0-1)
+
+
+### Example Config
+```json
+{
+  "majorVersion": 3,
+  "minorVersion": 4,
+  "patchVersion": 0,
+  "isDefaultConfig": false,
+  "displayMode": "format",
+  "fixedPosition": null,
+  "targetPositionOffset": null,
+  "timeDependencyDecimalPrecision": 1,
+  "timeDependencyDecimalOffset": 2,
+  "doIntermediateUpdates": true,
+  "judgments": [
+    { "threshold": 115, "text": "<size=250%><b>•", "color": [1, 1, 1, 1] },
+    { "threshold": 108, "text": "<size=120%>%B%c%A", "color": [1, 1, 1, 1] },
+    { "threshold": 0, "text": "<size=120%><alpha=#88>%B%c%A", "color": [1, 1, 1, 1] }
+  ],
+  "chainHeadJudgments":[
+    { "threshold": 85, "text": "<size=250%><b>•", "color": [1, 1, 1, 1] },
+    { "threshold": 78, "text": "<size=120%>%B%c", "color": [1, 1, 1, 1] },
+    { "threshold": 0, "text": "<size=120%><alpha=#88>%B%c", "color": [1, 1, 1, 1] }
+  ],
+  "chainLinkDisplay": {
+    "text": "<alpha=#66>•",
+    "color": [1, 1, 1, 1]
+  },
+  "beforeCutAngleJudgments": [
+    { "threshold": 70, "text": " " },
+    { "threshold": 63, "text": "-" },
+    { "threshold": 56, "text": "<color=#FFCC44>-</color>" },
+    { "threshold": 0, "text": "<color=#FF0000>-</color>" }
+  ],
+  "accuracyJudgments": [],
+  "afterCutAngleJudgments": [
+    { "threshold": 30, "text": " " },
+    { "threshold": 27, "text": "-" },
+    { "threshold": 24, "text": "<color=#FFCC44>-</color>" },
+    { "threshold": 0, "text": "<color=#FF0000>-</color>" }
+  ],
+  "timeDependencyJudgments": []
+}
+```

--- a/HitScoreVisualizer/Extensions/JudgmentExtensions.cs
+++ b/HitScoreVisualizer/Extensions/JudgmentExtensions.cs
@@ -1,0 +1,90 @@
+using HitScoreVisualizer.Settings;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace HitScoreVisualizer.Extensions
+{
+	internal static class JudgmentExtensions
+	{
+		public static string JudgeSegment(this IList<JudgmentSegment>? judgments, int scoreForSegment)
+		{
+			if (judgments == null)
+			{
+				return string.Empty;
+			}
+
+			foreach (var j in judgments)
+			{
+				if (scoreForSegment >= j.Threshold)
+				{
+					return j.Text ?? string.Empty;
+				}
+			}
+
+			return string.Empty;
+		}
+
+		public static string JudgeTimeDependenceSegment(this IList<TimeDependenceJudgmentSegment>? judgments, float scoreForSegment, int tdDecimalOffset, int tdDecimalPrecision)
+		{
+			if (judgments == null)
+			{
+				return string.Empty;
+			}
+
+			foreach (var j in judgments)
+			{
+				if (scoreForSegment >= j.Threshold)
+				{
+					return j.Text != null
+						? FormatTimeDependenceSegment(j.Text, scoreForSegment, tdDecimalOffset, tdDecimalPrecision)
+						: string.Empty;
+				}
+			}
+
+			return string.Empty;
+		}
+
+		private static string FormatTimeDependenceSegment(string unformattedText, float timeDependence, int tdDecimalOffset, int tdDecimalPrecision)
+		{
+			var builder = new StringBuilder();
+			var nextPercentIndex = unformattedText.IndexOf('%');
+			while (nextPercentIndex != -1)
+			{
+				builder.Append(unformattedText.Substring(0, nextPercentIndex));
+				if (unformattedText.Length == nextPercentIndex + 1)
+				{
+					unformattedText += " ";
+				}
+
+				var specifier = unformattedText[nextPercentIndex + 1];
+
+				switch (specifier)
+				{
+					case 't':
+						builder.Append(ConvertTimeDependencePrecision(timeDependence, tdDecimalOffset, tdDecimalPrecision));
+						break;
+					case '%':
+						builder.Append("%");
+						break;
+					case 'n':
+						builder.Append("\n");
+						break;
+					default:
+						builder.Append("%" + specifier);
+						break;
+				}
+
+				unformattedText = unformattedText.Remove(0, nextPercentIndex + 2);
+				nextPercentIndex = unformattedText.IndexOf('%');
+			}
+
+			return builder.Append(unformattedText).ToString();
+		}
+
+		private static string ConvertTimeDependencePrecision(float timeDependence, int decimalOffset, int decimalPrecision)
+		{
+			return (timeDependence * Mathf.Pow(10, decimalOffset)).ToString($"n{decimalPrecision}");
+		}
+	}
+}

--- a/HitScoreVisualizer/HarmonyPatches/EffectPoolsManualInstallerPatch.cs
+++ b/HitScoreVisualizer/HarmonyPatches/EffectPoolsManualInstallerPatch.cs
@@ -14,11 +14,16 @@ namespace HitScoreVisualizer.HarmonyPatches
 		[AffinityPatch(typeof(EffectPoolsManualInstaller), nameof(EffectPoolsManualInstaller.ManualInstallBindings))]
 		internal void ManualInstallBindingsPrefix(FlyingScoreEffect ____flyingScoreEffectPrefab)
 		{
+			var text = ____flyingScoreEffectPrefab._text;
+			text.richText = true;
+			text.enableWordWrapping = false;
+			text.overflowMode = TextOverflowModes.Overflow;
+
 			// Configure font shader and italics
-			____flyingScoreEffectPrefab._text.font = hsvConfig.HitScoreBloom
+			text.font = hsvConfig.HitScoreBloom
 				? bloomFontProvider.BloomFont
 				: bloomFontProvider.DefaultFont;
-			____flyingScoreEffectPrefab._text.fontStyle = hsvConfig.EnableItalics
+			text.fontStyle = hsvConfig.EnableItalics
 				? FontStyles.Italic
 				: FontStyles.Normal;
 		}

--- a/HitScoreVisualizer/HarmonyPatches/EffectPoolsManualInstallerPatch.cs
+++ b/HitScoreVisualizer/HarmonyPatches/EffectPoolsManualInstallerPatch.cs
@@ -5,26 +5,20 @@ using TMPro;
 
 namespace HitScoreVisualizer.HarmonyPatches
 {
-	internal class EffectPoolsManualInstallerPatch : IAffinity
+	internal class EffectPoolsManualInstallerPatch(BloomFontProvider bloomFontProvider, HSVConfig hsvConfig) : IAffinity
 	{
-		private readonly BloomFontProvider _bloomFontProvider;
-		private readonly HSVConfig _hsvConfig;
-
-		public EffectPoolsManualInstallerPatch(BloomFontProvider bloomFontProvider, HSVConfig hsvConfig)
-		{
-			_bloomFontProvider = bloomFontProvider;
-			_hsvConfig = hsvConfig;
-		}
+		private readonly BloomFontProvider bloomFontProvider = bloomFontProvider;
+		private readonly HSVConfig hsvConfig = hsvConfig;
 
 		[AffinityPrefix]
 		[AffinityPatch(typeof(EffectPoolsManualInstaller), nameof(EffectPoolsManualInstaller.ManualInstallBindings))]
 		internal void ManualInstallBindingsPrefix(FlyingScoreEffect ____flyingScoreEffectPrefab)
 		{
 			// Configure font shader and italics
-			____flyingScoreEffectPrefab._text.font = _hsvConfig.HitScoreBloom
-				? _bloomFontProvider.BloomFont
-				: _bloomFontProvider.DefaultFont;
-			____flyingScoreEffectPrefab._text.fontStyle = _hsvConfig.EnableItalics
+			____flyingScoreEffectPrefab._text.font = hsvConfig.HitScoreBloom
+				? bloomFontProvider.BloomFont
+				: bloomFontProvider.DefaultFont;
+			____flyingScoreEffectPrefab._text.fontStyle = hsvConfig.EnableItalics
 				? FontStyles.Italic
 				: FontStyles.Normal;
 		}

--- a/HitScoreVisualizer/HarmonyPatches/EffectPoolsManualInstallerPatch.cs
+++ b/HitScoreVisualizer/HarmonyPatches/EffectPoolsManualInstallerPatch.cs
@@ -1,22 +1,32 @@
 using HitScoreVisualizer.Services;
+using HitScoreVisualizer.Settings;
 using SiraUtil.Affinity;
+using TMPro;
 
 namespace HitScoreVisualizer.HarmonyPatches
 {
 	internal class EffectPoolsManualInstallerPatch : IAffinity
 	{
 		private readonly BloomFontProvider _bloomFontProvider;
+		private readonly HSVConfig _hsvConfig;
 
-		public EffectPoolsManualInstallerPatch(BloomFontProvider bloomFontProvider)
+		public EffectPoolsManualInstallerPatch(BloomFontProvider bloomFontProvider, HSVConfig hsvConfig)
 		{
 			_bloomFontProvider = bloomFontProvider;
+			_hsvConfig = hsvConfig;
 		}
 
 		[AffinityPrefix]
 		[AffinityPatch(typeof(EffectPoolsManualInstaller), nameof(EffectPoolsManualInstaller.ManualInstallBindings))]
 		internal void ManualInstallBindingsPrefix(FlyingScoreEffect ____flyingScoreEffectPrefab)
 		{
-			_bloomFontProvider.ConfigureFont(ref ____flyingScoreEffectPrefab._text);
+			// Configure font shader and italics
+			____flyingScoreEffectPrefab._text.font = _hsvConfig.HitScoreBloom
+				? _bloomFontProvider.BloomFont
+				: _bloomFontProvider.DefaultFont;
+			____flyingScoreEffectPrefab._text.fontStyle = _hsvConfig.EnableItalics
+				? FontStyles.Italic
+				: FontStyles.Normal;
 		}
 	}
 }

--- a/HitScoreVisualizer/HarmonyPatches/FlyingScoreEffectPatch.cs
+++ b/HitScoreVisualizer/HarmonyPatches/FlyingScoreEffectPatch.cs
@@ -4,22 +4,16 @@ using UnityEngine;
 
 namespace HitScoreVisualizer.HarmonyPatches
 {
-	internal class FlyingScoreEffectPatch : IAffinity
+	internal class FlyingScoreEffectPatch(JudgmentService judgmentService, ConfigProvider configProvider) : IAffinity
 	{
-		private readonly JudgmentService _judgmentService;
-		private readonly ConfigProvider _configProvider;
-
-		public FlyingScoreEffectPatch(JudgmentService judgmentService, ConfigProvider configProvider)
-		{
-			_judgmentService = judgmentService;
-			_configProvider = configProvider;
-		}
+		private readonly JudgmentService judgmentService = judgmentService;
+		private readonly ConfigProvider configProvider = configProvider;
 
 		[AffinityPrefix]
 		[AffinityPatch(typeof(FlyingScoreEffect), nameof(FlyingScoreEffect.InitAndPresent))]
 		internal bool InitAndPresent(ref FlyingScoreEffect __instance, IReadonlyCutScoreBuffer cutScoreBuffer, float duration, Vector3 targetPos, Color color)
 		{
-			var configuration = _configProvider.GetCurrentConfig();
+			var configuration = configProvider.GetCurrentConfig();
 			var noteCutInfo = cutScoreBuffer.noteCutInfo;
 
 			if (configuration != null)
@@ -79,7 +73,7 @@ namespace HitScoreVisualizer.HarmonyPatches
 		[AffinityPatch(typeof(FlyingScoreEffect), nameof(FlyingScoreEffect.HandleCutScoreBufferDidChange))]
 		internal bool HandleCutScoreBufferDidChange(FlyingScoreEffect __instance, CutScoreBuffer cutScoreBuffer)
 		{
-			var configuration = _configProvider.GetCurrentConfig();
+			var configuration = configProvider.GetCurrentConfig();
 			if (configuration == null || cutScoreBuffer.noteCutInfo.noteData.gameplayType is not NoteData.GameplayType.Normal)
 			{
 				// Run original implementation
@@ -98,7 +92,7 @@ namespace HitScoreVisualizer.HarmonyPatches
 		[AffinityPatch(typeof(FlyingScoreEffect), nameof(FlyingScoreEffect.HandleCutScoreBufferDidFinish))]
 		internal void HandleCutScoreBufferDidFinish(FlyingScoreEffect __instance, CutScoreBuffer cutScoreBuffer)
 		{
-			var configuration = _configProvider.GetCurrentConfig();
+			var configuration = configProvider.GetCurrentConfig();
 			if (configuration != null && cutScoreBuffer.noteCutInfo.noteData.gameplayType is NoteData.GameplayType.Normal)
 			{
 				Judge(__instance, cutScoreBuffer);
@@ -107,7 +101,7 @@ namespace HitScoreVisualizer.HarmonyPatches
 
 		private void Judge(FlyingScoreEffect flyingScoreEffect, CutScoreBuffer cutScoreBuffer)
 		{
-			_judgmentService.Judge(ref flyingScoreEffect._text, ref flyingScoreEffect._color, cutScoreBuffer);
+			judgmentService.Judge(ref flyingScoreEffect._text, ref flyingScoreEffect._color, cutScoreBuffer);
 		}
 	}
 }

--- a/HitScoreVisualizer/HitScoreVisualizer.csproj
+++ b/HitScoreVisualizer/HitScoreVisualizer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
-    <LangVersion>9</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LocalRefsDir Condition="Exists('..\Refs')">..\Refs</LocalRefsDir>

--- a/HitScoreVisualizer/Installers/HsvAppInstaller.cs
+++ b/HitScoreVisualizer/Installers/HsvAppInstaller.cs
@@ -5,18 +5,13 @@ using Zenject;
 
 namespace HitScoreVisualizer.Installers
 {
-	internal sealed class HsvAppInstaller : Installer
+	internal sealed class HsvAppInstaller(HSVConfig hsvConfig) : Installer
 	{
-		private readonly HSVConfig _hsvConfig;
-
-		internal HsvAppInstaller(HSVConfig hsvConfig)
-		{
-			_hsvConfig = hsvConfig;
-		}
+		private readonly HSVConfig hsvConfig = hsvConfig;
 
 		public override void InstallBindings()
 		{
-			Container.BindInstance(_hsvConfig);
+			Container.BindInstance(hsvConfig);
 			Container.BindInterfacesAndSelfTo<ConfigProvider>().AsSingle();
 			Container.BindInterfacesAndSelfTo<BloomFontProvider>().AsSingle();
 

--- a/HitScoreVisualizer/Models/ConfigFileInfo.cs
+++ b/HitScoreVisualizer/Models/ConfigFileInfo.cs
@@ -1,20 +1,16 @@
-﻿using System;
+using System;
 using BeatSaberMarkupLanguage.Attributes;
 using HitScoreVisualizer.Settings;
 using Version = Hive.Versioning.Version;
 
 namespace HitScoreVisualizer.Models
 {
-	internal class ConfigFileInfo
+	internal class ConfigFileInfo(string fileName, string filePath)
 	{
-		public ConfigFileInfo(string fileName, string filePath)
-		{
-			ConfigName = fileName;
-			ConfigPath = filePath;
-		}
+		public string ConfigPath { get; } = filePath;
 
 		[UIValue("config-name")]
-		public string ConfigName { get; }
+		public string ConfigName { get; } = fileName;
 
 		[UIValue("config-description")]
 		public string ConfigDescription => State switch
@@ -27,8 +23,6 @@ namespace HitScoreVisualizer.Models
 			ConfigState.Broken => "<color=\"red\">Invalid config. Not selectable...",
 			_ => throw new NotImplementedException()
 		};
-
-		public string ConfigPath { get; }
 
 		public Configuration? Configuration { get; set; }
 		public ConfigState State { get; set; }

--- a/HitScoreVisualizer/Services/BloomFontProvider.cs
+++ b/HitScoreVisualizer/Services/BloomFontProvider.cs
@@ -9,15 +9,11 @@ namespace HitScoreVisualizer.Services
 {
 	internal class BloomFontProvider : IDisposable
 	{
-		private readonly HSVConfig _hsvConfig;
-
 		private readonly Lazy<TMP_FontAsset> _cachedTekoFont;
 		private readonly Lazy<TMP_FontAsset> _bloomTekoFont;
 
-		public BloomFontProvider(HSVConfig hsvConfig)
+		public BloomFontProvider()
 		{
-			_hsvConfig = hsvConfig;
-
 			var tekoFontAsset = Resources.FindObjectsOfTypeAll<TMP_FontAsset>().First(x => x.name.Contains("Teko-Medium SDF"));
 
 			_cachedTekoFont = new Lazy<TMP_FontAsset>(() => CopyFontAsset(tekoFontAsset), LazyThreadSafetyMode.ExecutionAndPublication);
@@ -31,10 +27,9 @@ namespace HitScoreVisualizer.Services
 			}, LazyThreadSafetyMode.ExecutionAndPublication);
 		}
 
-		public void ConfigureFont(ref TextMeshPro text)
-		{
-			text.font = _hsvConfig.HitScoreBloom ? _bloomTekoFont.Value : _cachedTekoFont.Value;
-		}
+		public TMP_FontAsset BloomFont => _bloomTekoFont.Value;
+
+		public TMP_FontAsset DefaultFont => _cachedTekoFont.Value;
 
 		private static TMP_FontAsset CopyFontAsset(TMP_FontAsset original, string newName = "")
 		{

--- a/HitScoreVisualizer/Services/BloomFontProvider.cs
+++ b/HitScoreVisualizer/Services/BloomFontProvider.cs
@@ -9,15 +9,15 @@ namespace HitScoreVisualizer.Services
 {
 	internal class BloomFontProvider : IDisposable
 	{
-		private readonly Lazy<TMP_FontAsset> _cachedTekoFont;
-		private readonly Lazy<TMP_FontAsset> _bloomTekoFont;
+		private readonly Lazy<TMP_FontAsset> cachedTekoFont;
+		private readonly Lazy<TMP_FontAsset> bloomTekoFont;
 
 		public BloomFontProvider()
 		{
 			var tekoFontAsset = Resources.FindObjectsOfTypeAll<TMP_FontAsset>().First(x => x.name.Contains("Teko-Medium SDF"));
 
-			_cachedTekoFont = new Lazy<TMP_FontAsset>(() => CopyFontAsset(tekoFontAsset), LazyThreadSafetyMode.ExecutionAndPublication);
-			_bloomTekoFont = new Lazy<TMP_FontAsset>(() =>
+			cachedTekoFont = new Lazy<TMP_FontAsset>(() => CopyFontAsset(tekoFontAsset), LazyThreadSafetyMode.ExecutionAndPublication);
+			bloomTekoFont = new Lazy<TMP_FontAsset>(() =>
 			{
 				var distanceFieldShader = Resources.FindObjectsOfTypeAll<Shader>().First(x => x.name.Contains("TextMeshPro/Distance Field"));
 				var bloomTekoFont = CopyFontAsset(tekoFontAsset, "Teko-Medium SDF (Bloom)");
@@ -27,9 +27,9 @@ namespace HitScoreVisualizer.Services
 			}, LazyThreadSafetyMode.ExecutionAndPublication);
 		}
 
-		public TMP_FontAsset BloomFont => _bloomTekoFont.Value;
+		public TMP_FontAsset BloomFont => bloomTekoFont.Value;
 
-		public TMP_FontAsset DefaultFont => _cachedTekoFont.Value;
+		public TMP_FontAsset DefaultFont => cachedTekoFont.Value;
 
 		private static TMP_FontAsset CopyFontAsset(TMP_FontAsset original, string newName = "")
 		{
@@ -58,9 +58,9 @@ namespace HitScoreVisualizer.Services
 
 		public void Dispose()
 		{
-			if (_bloomTekoFont.IsValueCreated)
+			if (bloomTekoFont.IsValueCreated)
 			{
-				UnityEngine.Object.Destroy(_bloomTekoFont.Value);
+				UnityEngine.Object.Destroy(bloomTekoFont.Value);
 			}
 		}
 	}

--- a/HitScoreVisualizer/Services/ConfigProvider.cs
+++ b/HitScoreVisualizer/Services/ConfigProvider.cs
@@ -301,7 +301,7 @@ namespace HitScoreVisualizer.Services
 		// ReSharper disable once CognitiveComplexity
 		private bool Validate(Configuration configuration, string configName)
 		{
-			if (!configuration.Judgments?.Any() ?? true)
+			if (!configuration.NormalJudgments?.Any() ?? true)
 			{
 				siraLog.Warn($"No judgments found for {configName}");
 				return false;
@@ -367,8 +367,8 @@ namespace HitScoreVisualizer.Services
 		// ReSharper disable once CognitiveComplexity
 		private bool ValidateJudgments(Configuration configuration, string configName)
 		{
-			configuration.Judgments = configuration.Judgments!.OrderByDescending(x => x.Threshold).ToList();
-			var prevJudgment = configuration.Judgments.First();
+			configuration.NormalJudgments = configuration.NormalJudgments!.OrderByDescending(x => x.Threshold).ToList();
+			var prevJudgment = configuration.NormalJudgments.First();
 			if (prevJudgment.Fade)
 			{
 				prevJudgment.Fade = false;
@@ -380,11 +380,11 @@ namespace HitScoreVisualizer.Services
 				return false;
 			}
 
-			if (configuration.Judgments.Count > 1)
+			if (configuration.NormalJudgments.Count > 1)
 			{
-				for (var i = 1; i < configuration.Judgments.Count; i++)
+				for (var i = 1; i < configuration.NormalJudgments.Count; i++)
 				{
-					var currentJudgment = configuration.Judgments[i];
+					var currentJudgment = configuration.NormalJudgments[i];
 					if (prevJudgment.Threshold != currentJudgment.Threshold)
 					{
 						if (!ValidateJudgmentColor(currentJudgment, configName))
@@ -405,7 +405,7 @@ namespace HitScoreVisualizer.Services
 			return true;
 		}
 
-		private bool ValidateJudgmentColor(Judgment judgment, string configName)
+		private bool ValidateJudgmentColor(NormalJudgment judgment, string configName)
 		{
 			if (judgment.Color.Count != 4)
 			{
@@ -492,9 +492,9 @@ namespace HitScoreVisualizer.Services
 
 		private static bool RunMigration2_1_0(Configuration configuration)
 		{
-			if (configuration.Judgments != null)
+			if (configuration.NormalJudgments != null)
 			{
-				foreach (var j in configuration.Judgments.Where(j => j.Threshold == 110))
+				foreach (var j in configuration.NormalJudgments.Where(j => j.Threshold == 110))
 				{
 					j.Threshold = 115;
 				}

--- a/HitScoreVisualizer/Services/ConfigProvider.cs
+++ b/HitScoreVisualizer/Services/ConfigProvider.cs
@@ -363,10 +363,10 @@ namespace HitScoreVisualizer.Services
 		private bool ValidateJudgments(Configuration configuration, string configName)
 		{
 			configuration.NormalJudgments = configuration.NormalJudgments!.OrderByDescending(x => x.Threshold).ToList();
-			var prevJudgment = configuration.NormalJudgments.First();
+			var prevJudgment = configuration.NormalJudgments[0];
 			if (prevJudgment.Fade)
 			{
-				prevJudgment.Fade = false;
+				prevJudgment = new(prevJudgment.Threshold, prevJudgment.Text, prevJudgment.Color, false);
 			}
 
 			if (!ValidateJudgmentColor(prevJudgment, configName))
@@ -489,18 +489,26 @@ namespace HitScoreVisualizer.Services
 		{
 			if (configuration.NormalJudgments != null)
 			{
+				List<NormalJudgment> migratedJudgments = [];
+
 				foreach (var j in configuration.NormalJudgments.Where(j => j.Threshold == 110))
 				{
-					j.Threshold = 115;
+					migratedJudgments.Add(new(115, j.Text, j.Color, j.Fade));
 				}
+
+				configuration.NormalJudgments = migratedJudgments;
 			}
 
 			if (configuration.AccuracyJudgments != null)
 			{
-				foreach (var aj in configuration.AccuracyJudgments.Where(aj => aj.Threshold == 10))
+				List<JudgmentSegment> migratedSegments = [];
+
+				foreach (var s in configuration.AccuracyJudgments.Where(aj => aj.Threshold == 10))
 				{
-					aj.Threshold = 15;
+					migratedSegments.Add(new(15, s.Text));
 				}
+
+				configuration.AccuracyJudgments = migratedSegments;
 			}
 
 			return true;

--- a/HitScoreVisualizer/Services/ConfigProvider.cs
+++ b/HitScoreVisualizer/Services/ConfigProvider.cs
@@ -47,7 +47,7 @@ namespace HitScoreVisualizer.Services
 				DefaultValueHandling = DefaultValueHandling.Include,
 				NullValueHandling = NullValueHandling.Ignore,
 				Formatting = Formatting.Indented,
-				Converters = new List<JsonConverter> { new Vector3Converter() },
+				Converters = [ new Vector3Converter() ],
 				ContractResolver = ShouldNotSerializeContractResolver.Instance
 			};
 			hsvConfigsFolderPath = Path.Combine(UnityGame.UserDataPath, nameof(HitScoreVisualizer));
@@ -119,7 +119,7 @@ namespace HitScoreVisualizer.Services
 		internal async Task<IEnumerable<ConfigFileInfo>> ListAvailableConfigs()
 		{
 			var configFileInfoList = Directory
-				.EnumerateFiles(hsvConfigsFolderPath, "*", SearchOption.AllDirectories)
+				.EnumerateFiles(hsvConfigsFolderPath, "*.json", SearchOption.AllDirectories)
 				.Where(path => !path.StartsWith(hsvConfigsBackupFolderPath))
 				.Select(x => new ConfigFileInfo(Path.GetFileNameWithoutExtension(x), x.Substring(hsvConfigsFolderPath.Length + 1)))
 				.ToList();
@@ -225,7 +225,7 @@ namespace HitScoreVisualizer.Services
 			}
 			catch (Exception ex)
 			{
-				siraLog.Warn(ex);
+				siraLog.Warn($"Problem encountered when trying to load a config;\nFile path: {relativePath}\n{ex}");
 				// Expected behaviour when file isn't an actual hsv config file...
 				return null;
 			}
@@ -478,9 +478,9 @@ namespace HitScoreVisualizer.Services
 
 		private static bool RunMigration2_0_0(Configuration configuration)
 		{
-			configuration.BeforeCutAngleJudgments = new List<JudgmentSegment> { JudgmentSegment.Default };
-			configuration.AccuracyJudgments = new List<JudgmentSegment> { JudgmentSegment.Default };
-			configuration.AfterCutAngleJudgments = new List<JudgmentSegment> { JudgmentSegment.Default };
+			configuration.BeforeCutAngleJudgments = [JudgmentSegment.Default];
+			configuration.AccuracyJudgments = [JudgmentSegment.Default];
+			configuration.AfterCutAngleJudgments = [JudgmentSegment.Default];
 
 			return true;
 		}

--- a/HitScoreVisualizer/Services/ConfigProvider.cs
+++ b/HitScoreVisualizer/Services/ConfigProvider.cs
@@ -32,9 +32,9 @@ namespace HitScoreVisualizer.Services
 		private readonly Version minimumMigratableVersion;
 		private readonly Version maximumMigrationNeededVersion;
 
-		private Configuration? currentConfig;
-
 		internal string? CurrentConfigPath => hsvConfig.ConfigFilePath;
+
+		public Configuration? CurrentConfig { get; private set; }
 
 		internal ConfigProvider(SiraLog siraLog, HSVConfig hsvConfig, UBinder<Plugin, PluginMetadata> pluginMetadata)
 		{
@@ -116,11 +116,6 @@ namespace HitScoreVisualizer.Services
 			await SelectUserConfig(configFileInfo).ConfigureAwait(false);
 		}
 
-		public Configuration? GetCurrentConfig()
-		{
-			return currentConfig;
-		}
-
 		internal async Task<IEnumerable<ConfigFileInfo>> ListAvailableConfigs()
 		{
 			var configFileInfoList = Directory
@@ -198,14 +193,14 @@ namespace HitScoreVisualizer.Services
 
 			if (Validate(configFileInfo.Configuration!, configFileInfo.ConfigName))
 			{
-				currentConfig = configFileInfo.Configuration;
+				CurrentConfig = configFileInfo.Configuration;
 				hsvConfig.ConfigFilePath = configFileInfo.ConfigPath;
 			}
 		}
 
 		internal void UnselectUserConfig()
 		{
-			currentConfig = null;
+			CurrentConfig = null;
 			hsvConfig.ConfigFilePath = null;
 		}
 

--- a/HitScoreVisualizer/Services/ConfigProvider.cs
+++ b/HitScoreVisualizer/Services/ConfigProvider.cs
@@ -19,30 +19,30 @@ namespace HitScoreVisualizer.Services
 {
 	public class ConfigProvider : IInitializable
 	{
-		private readonly SiraLog _siraLog;
-		private readonly HSVConfig _hsvConfig;
-		private readonly Version _pluginVersion;
+		private readonly SiraLog siraLog;
+		private readonly HSVConfig hsvConfig;
+		private readonly Version pluginVersion;
 
-		private readonly string _hsvConfigsFolderPath;
-		private readonly string _hsvConfigsBackupFolderPath;
-		private readonly JsonSerializerSettings _jsonSerializerSettings;
+		private readonly string hsvConfigsFolderPath;
+		private readonly string hsvConfigsBackupFolderPath;
+		private readonly JsonSerializerSettings jsonSerializerSettings;
 
-		private readonly Dictionary<Version, Func<Configuration, bool>> _migrationActions;
+		private readonly Dictionary<Version, Func<Configuration, bool>> migrationActions;
 
-		private readonly Version _minimumMigratableVersion;
-		private readonly Version _maximumMigrationNeededVersion;
+		private readonly Version minimumMigratableVersion;
+		private readonly Version maximumMigrationNeededVersion;
 
-		private Configuration? _currentConfig;
+		private Configuration? currentConfig;
 
-		internal string? CurrentConfigPath => _hsvConfig.ConfigFilePath;
+		internal string? CurrentConfigPath => hsvConfig.ConfigFilePath;
 
 		internal ConfigProvider(SiraLog siraLog, HSVConfig hsvConfig, UBinder<Plugin, PluginMetadata> pluginMetadata)
 		{
-			_siraLog = siraLog;
-			_hsvConfig = hsvConfig;
-			_pluginVersion = pluginMetadata.Value.HVersion;
+			this.siraLog = siraLog;
+			this.hsvConfig = hsvConfig;
+			pluginVersion = pluginMetadata.Value.HVersion;
 
-			_jsonSerializerSettings = new JsonSerializerSettings
+			jsonSerializerSettings = new JsonSerializerSettings
 			{
 				DefaultValueHandling = DefaultValueHandling.Include,
 				NullValueHandling = NullValueHandling.Ignore,
@@ -50,10 +50,10 @@ namespace HitScoreVisualizer.Services
 				Converters = new List<JsonConverter> { new Vector3Converter() },
 				ContractResolver = ShouldNotSerializeContractResolver.Instance
 			};
-			_hsvConfigsFolderPath = Path.Combine(UnityGame.UserDataPath, nameof(HitScoreVisualizer));
-			_hsvConfigsBackupFolderPath = Path.Combine(_hsvConfigsFolderPath, "Backups");
+			hsvConfigsFolderPath = Path.Combine(UnityGame.UserDataPath, nameof(HitScoreVisualizer));
+			hsvConfigsBackupFolderPath = Path.Combine(hsvConfigsFolderPath, "Backups");
 
-			_migrationActions = new Dictionary<Version, Func<Configuration, bool>>
+			migrationActions = new Dictionary<Version, Func<Configuration, bool>>
 			{
 				{ new Version(2, 0, 0), RunMigration2_0_0 },
 				{ new Version(2, 1, 0), RunMigration2_1_0 },
@@ -61,56 +61,56 @@ namespace HitScoreVisualizer.Services
 				{ new Version(3, 2, 0), RunMigration3_2_0 }
 			};
 
-			_minimumMigratableVersion = _migrationActions.Keys.Min();
-			_maximumMigrationNeededVersion = _migrationActions.Keys.Max();
+			minimumMigratableVersion = migrationActions.Keys.Min();
+			maximumMigrationNeededVersion = migrationActions.Keys.Max();
 		}
 
 		public async void Initialize()
 		{
 			if (CreateHsvConfigsFolderIfYeetedByPlayer())
 			{
-				await SaveConfig(Path.Combine(_hsvConfigsFolderPath, "HitScoreVisualizerConfig (default).json"), Configuration.Default).ConfigureAwait(false);
+				await SaveConfig(Path.Combine(hsvConfigsFolderPath, "HitScoreVisualizerConfig (default).json"), Configuration.Default).ConfigureAwait(false);
 
 				var oldHsvConfigPath = Path.Combine(UnityGame.UserDataPath, "HitScoreVisualizerConfig.json");
 				if (File.Exists(oldHsvConfigPath))
 				{
 					try
 					{
-						var destinationHsvConfigPath = Path.Combine(_hsvConfigsFolderPath, "HitScoreVisualizerConfig (imported).json");
+						var destinationHsvConfigPath = Path.Combine(hsvConfigsFolderPath, "HitScoreVisualizerConfig (imported).json");
 						File.Move(oldHsvConfigPath, destinationHsvConfigPath);
 
-						_hsvConfig.ConfigFilePath = destinationHsvConfigPath;
+						hsvConfig.ConfigFilePath = destinationHsvConfigPath;
 					}
 					catch (Exception e)
 					{
-						_siraLog.Warn(e);
+						siraLog.Warn(e);
 					}
 				}
 			}
 
-			if (_hsvConfig.ConfigFilePath == null)
+			if (hsvConfig.ConfigFilePath == null)
 			{
 				return;
 			}
 
-			var fullPath = Path.Combine(_hsvConfigsFolderPath, _hsvConfig.ConfigFilePath);
+			var fullPath = Path.Combine(hsvConfigsFolderPath, hsvConfig.ConfigFilePath);
 			if (!File.Exists(fullPath))
 			{
-				_hsvConfig.ConfigFilePath = null;
+				hsvConfig.ConfigFilePath = null;
 				return;
 			}
 
-			var userConfig = await LoadConfig(_hsvConfig.ConfigFilePath).ConfigureAwait(false);
+			var userConfig = await LoadConfig(hsvConfig.ConfigFilePath).ConfigureAwait(false);
 			if (userConfig == null)
 			{
-				_siraLog.Warn($"Couldn't load userConfig at {fullPath}");
+				siraLog.Warn($"Couldn't load userConfig at {fullPath}");
 				return;
 			}
 
-			var configFileInfo = new ConfigFileInfo(Path.GetFileNameWithoutExtension(_hsvConfig.ConfigFilePath), _hsvConfig.ConfigFilePath)
+			var configFileInfo = new ConfigFileInfo(Path.GetFileNameWithoutExtension(hsvConfig.ConfigFilePath), hsvConfig.ConfigFilePath)
 			{
 				Configuration = userConfig,
-				State = GetConfigState(userConfig, Path.GetFileNameWithoutExtension(_hsvConfig.ConfigFilePath), true)
+				State = GetConfigState(userConfig, Path.GetFileNameWithoutExtension(hsvConfig.ConfigFilePath), true)
 			};
 
 			await SelectUserConfig(configFileInfo).ConfigureAwait(false);
@@ -118,20 +118,20 @@ namespace HitScoreVisualizer.Services
 
 		public Configuration? GetCurrentConfig()
 		{
-			return _currentConfig;
+			return currentConfig;
 		}
 
 		internal async Task<IEnumerable<ConfigFileInfo>> ListAvailableConfigs()
 		{
 			var configFileInfoList = Directory
-				.EnumerateFiles(_hsvConfigsFolderPath, "*", SearchOption.AllDirectories)
-				.Where(path => !path.StartsWith(_hsvConfigsBackupFolderPath))
-				.Select(x => new ConfigFileInfo(Path.GetFileNameWithoutExtension(x), x.Substring(_hsvConfigsFolderPath.Length + 1)))
+				.EnumerateFiles(hsvConfigsFolderPath, "*", SearchOption.AllDirectories)
+				.Where(path => !path.StartsWith(hsvConfigsBackupFolderPath))
+				.Select(x => new ConfigFileInfo(Path.GetFileNameWithoutExtension(x), x.Substring(hsvConfigsFolderPath.Length + 1)))
 				.ToList();
 
 			foreach (var configInfo in configFileInfoList)
 			{
-				configInfo.Configuration = await LoadConfig(Path.Combine(_hsvConfigsFolderPath, configInfo.ConfigPath)).ConfigureAwait(false);
+				configInfo.Configuration = await LoadConfig(Path.Combine(hsvConfigsFolderPath, configInfo.ConfigPath)).ConfigureAwait(false);
 				configInfo.State = GetConfigState(configInfo.Configuration, configInfo.ConfigName);
 			}
 
@@ -153,17 +153,17 @@ namespace HitScoreVisualizer.Services
 			// safe-guarding just to be sure
 			if (!ConfigSelectable(configFileInfo.State))
 			{
-				_hsvConfig.ConfigFilePath = null;
+				hsvConfig.ConfigFilePath = null;
 				return;
 			}
 
 			if (configFileInfo.State == ConfigState.NeedsMigration)
 			{
-				var existingConfigFullPath = Path.Combine(_hsvConfigsFolderPath, configFileInfo.ConfigPath);
-				_siraLog.Notice($"Config at path '{existingConfigFullPath}' requires migration. Starting automagical config migration logic.");
+				var existingConfigFullPath = Path.Combine(hsvConfigsFolderPath, configFileInfo.ConfigPath);
+				siraLog.Notice($"Config at path '{existingConfigFullPath}' requires migration. Starting automagical config migration logic.");
 
 				// Create backups folder if it not exists
-				var backupFolderPath = Path.GetDirectoryName(Path.Combine(_hsvConfigsBackupFolderPath, configFileInfo.ConfigPath))!;
+				var backupFolderPath = Path.GetDirectoryName(Path.Combine(hsvConfigsBackupFolderPath, configFileInfo.ConfigPath))!;
 				Directory.CreateDirectory(backupFolderPath);
 
 				var newFileName = $"{Path.GetFileNameWithoutExtension(existingConfigFullPath)} (backup of config made for {configFileInfo.Configuration!.Version})";
@@ -177,41 +177,41 @@ namespace HitScoreVisualizer.Services
 					combinedConfigBackupPath = Path.Combine(backupFolderPath, newFileName + fileExtension);
 				}
 
-				_siraLog.Debug($"Backing up config file at '{existingConfigFullPath}' to '{combinedConfigBackupPath}'");
+				siraLog.Debug($"Backing up config file at '{existingConfigFullPath}' to '{combinedConfigBackupPath}'");
 				File.Copy(existingConfigFullPath, combinedConfigBackupPath);
 
 				if (configFileInfo.Configuration!.IsDefaultConfig)
 				{
-					_siraLog.Warn("Config is marked as default config and will therefore be reset to defaults");
+					siraLog.Warn("Config is marked as default config and will therefore be reset to defaults");
 					configFileInfo.Configuration = Configuration.Default;
 				}
 				else
 				{
-					_siraLog.Debug("Starting actual config migration logic for config");
+					siraLog.Debug("Starting actual config migration logic for config");
 					RunMigration(configFileInfo.Configuration!);
 				}
 
 				await SaveConfig(configFileInfo.ConfigPath, configFileInfo.Configuration).ConfigureAwait(false);
 
-				_siraLog.Debug($"Config migration finished successfully and updated config is stored to disk at path: '{existingConfigFullPath}'");
+				siraLog.Debug($"Config migration finished successfully and updated config is stored to disk at path: '{existingConfigFullPath}'");
 			}
 
 			if (Validate(configFileInfo.Configuration!, configFileInfo.ConfigName))
 			{
-				_currentConfig = configFileInfo.Configuration;
-				_hsvConfig.ConfigFilePath = configFileInfo.ConfigPath;
+				currentConfig = configFileInfo.Configuration;
+				hsvConfig.ConfigFilePath = configFileInfo.ConfigPath;
 			}
 		}
 
 		internal void UnselectUserConfig()
 		{
-			_currentConfig = null;
-			_hsvConfig.ConfigFilePath = null;
+			currentConfig = null;
+			hsvConfig.ConfigFilePath = null;
 		}
 
 		internal void YeetConfig(string relativePath)
 		{
-			var fullPath = Path.Combine(_hsvConfigsFolderPath, relativePath);
+			var fullPath = Path.Combine(hsvConfigsFolderPath, relativePath);
 			if (File.Exists(fullPath))
 			{
 				File.Delete(fullPath);
@@ -224,13 +224,13 @@ namespace HitScoreVisualizer.Services
 
 			try
 			{
-				using var streamReader = new StreamReader(Path.Combine(_hsvConfigsFolderPath, relativePath));
+				using var streamReader = new StreamReader(Path.Combine(hsvConfigsFolderPath, relativePath));
 				var content = await streamReader.ReadToEndAsync().ConfigureAwait(false);
-				return JsonConvert.DeserializeObject<Configuration>(content, _jsonSerializerSettings);
+				return JsonConvert.DeserializeObject<Configuration>(content, jsonSerializerSettings);
 			}
 			catch (Exception ex)
 			{
-				_siraLog.Warn(ex);
+				siraLog.Warn(ex);
 				// Expected behaviour when file isn't an actual hsv config file...
 				return null;
 			}
@@ -240,7 +240,7 @@ namespace HitScoreVisualizer.Services
 		{
 			CreateHsvConfigsFolderIfYeetedByPlayer(false);
 
-			var fullPath = Path.Combine(_hsvConfigsFolderPath, relativePath);
+			var fullPath = Path.Combine(hsvConfigsFolderPath, relativePath);
 			var folderPath = Path.GetDirectoryName(fullPath);
 			if (folderPath != null && Directory.Exists(folderPath))
 			{
@@ -250,12 +250,12 @@ namespace HitScoreVisualizer.Services
 			try
 			{
 				using var streamWriter = new StreamWriter(fullPath, false);
-				var content = JsonConvert.SerializeObject(configuration, Formatting.Indented, _jsonSerializerSettings);
+				var content = JsonConvert.SerializeObject(configuration, Formatting.Indented, jsonSerializerSettings);
 				await streamWriter.WriteAsync(content).ConfigureAwait(false);
 			}
 			catch (Exception e)
 			{
-				_siraLog.Error(e);
+				siraLog.Error(e);
 			}
 		}
 
@@ -265,7 +265,7 @@ namespace HitScoreVisualizer.Services
 			{
 				if (shouldLogWarning)
 				{
-					_siraLog.Warn(message);
+					siraLog.Warn(message);
 				}
 			}
 
@@ -276,22 +276,22 @@ namespace HitScoreVisualizer.Services
 			}
 
 			// Both full version comparison and check on major, minor or patch version inequality in case the mod is versioned with a pre-release id
-			if (configuration.Version > _pluginVersion &&
-			    (configuration.Version.Major != _pluginVersion.Major || configuration.Version.Minor != _pluginVersion.Minor || configuration.Version.Patch != _pluginVersion.Patch))
+			if (configuration.Version > pluginVersion &&
+			    (configuration.Version.Major != pluginVersion.Major || configuration.Version.Minor != pluginVersion.Minor || configuration.Version.Patch != pluginVersion.Patch))
 			{
-				LogWarning($"Config {configName} is made for a newer version of HSV than is currently installed. Targets {configuration.Version} while only {_pluginVersion} is installed");
+				LogWarning($"Config {configName} is made for a newer version of HSV than is currently installed. Targets {configuration.Version} while only {pluginVersion} is installed");
 				return ConfigState.NewerVersion;
 			}
 
-			if (configuration.Version < _minimumMigratableVersion)
+			if (configuration.Version < minimumMigratableVersion)
 			{
 				LogWarning($"Config {configName} is too old and cannot be migrated. Please manually update said config to a newer version of HSV");
 				return ConfigState.Incompatible;
 			}
 
-			if (configuration.Version < _maximumMigrationNeededVersion)
+			if (configuration.Version < maximumMigrationNeededVersion)
 			{
-				LogWarning($"Config {configName} is is made for an older version of HSV, but can be migrated (safely?). Targets {configuration.Version} while version {_pluginVersion} is installed");
+				LogWarning($"Config {configName} is is made for an older version of HSV, but can be migrated (safely?). Targets {configuration.Version} while version {pluginVersion} is installed");
 				return ConfigState.NeedsMigration;
 			}
 
@@ -303,7 +303,7 @@ namespace HitScoreVisualizer.Services
 		{
 			if (!configuration.Judgments?.Any() ?? true)
 			{
-				_siraLog.Warn($"No judgments found for {configName}");
+				siraLog.Warn($"No judgments found for {configName}");
 				return false;
 			}
 
@@ -315,13 +315,13 @@ namespace HitScoreVisualizer.Services
 			// 99 is the max for NumberFormatInfo.NumberDecimalDigits
 			if (configuration.TimeDependenceDecimalPrecision < 0 || configuration.TimeDependenceDecimalPrecision > 99)
 			{
-				_siraLog.Warn($"timeDependencyDecimalPrecision value {configuration.TimeDependenceDecimalPrecision} is outside the range of acceptable values [0, 99]");
+				siraLog.Warn($"timeDependencyDecimalPrecision value {configuration.TimeDependenceDecimalPrecision} is outside the range of acceptable values [0, 99]");
 				return false;
 			}
 
 			if (configuration.TimeDependenceDecimalOffset < 0 || configuration.TimeDependenceDecimalOffset > Math.Log10(float.MaxValue))
 			{
-				_siraLog.Warn($"timeDependencyDecimalOffset value {configuration.TimeDependenceDecimalOffset} is outside the range of acceptable values [0, {(int) Math.Log10(float.MaxValue)}]");
+				siraLog.Warn($"timeDependencyDecimalOffset value {configuration.TimeDependenceDecimalOffset} is outside the range of acceptable values [0, {(int) Math.Log10(float.MaxValue)}]");
 				return false;
 			}
 
@@ -376,7 +376,7 @@ namespace HitScoreVisualizer.Services
 
 			if (!ValidateJudgmentColor(prevJudgment, configName))
 			{
-				_siraLog.Warn($"Judgment entry for threshold {prevJudgment.Threshold} has invalid color in {configName}");
+				siraLog.Warn($"Judgment entry for threshold {prevJudgment.Threshold} has invalid color in {configName}");
 				return false;
 			}
 
@@ -389,7 +389,7 @@ namespace HitScoreVisualizer.Services
 					{
 						if (!ValidateJudgmentColor(currentJudgment, configName))
 						{
-							_siraLog.Warn($"Judgment entry for threshold {currentJudgment.Threshold} has invalid color in {configName}");
+							siraLog.Warn($"Judgment entry for threshold {currentJudgment.Threshold} has invalid color in {configName}");
 							return false;
 						}
 
@@ -397,7 +397,7 @@ namespace HitScoreVisualizer.Services
 						continue;
 					}
 
-					_siraLog.Warn($"Duplicate entry found for threshold {currentJudgment.Threshold} in {configName}");
+					siraLog.Warn($"Duplicate entry found for threshold {currentJudgment.Threshold} in {configName}");
 					return false;
 				}
 			}
@@ -409,7 +409,7 @@ namespace HitScoreVisualizer.Services
 		{
 			if (judgment.Color.Count != 4)
 			{
-				_siraLog.Warn($"Judgment for threshold {judgment.Threshold} has invalid color in {configName}! Make sure to include exactly 4 numbers for each judgment's color!");
+				siraLog.Warn($"Judgment for threshold {judgment.Threshold} has invalid color in {configName}! Make sure to include exactly 4 numbers for each judgment's color!");
 				return false;
 			}
 
@@ -418,7 +418,7 @@ namespace HitScoreVisualizer.Services
 				return true;
 			}
 
-			_siraLog.Warn($"Judgment for threshold {judgment.Threshold} has invalid color in {configName}! Make sure to include exactly 4 numbers that are greater or equal than 0 (and preferably smaller or equal than 1) for each judgment's color!");
+			siraLog.Warn($"Judgment for threshold {judgment.Threshold} has invalid color in {configName}! Make sure to include exactly 4 numbers that are greater or equal than 0 (and preferably smaller or equal than 1) for each judgment's color!");
 			return false;
 		}
 
@@ -439,7 +439,7 @@ namespace HitScoreVisualizer.Services
 					continue;
 				}
 
-				_siraLog.Warn($"Duplicate entry found for threshold {currentJudgment.Threshold} in {configName}");
+				siraLog.Warn($"Duplicate entry found for threshold {currentJudgment.Threshold} in {configName}");
 				return false;
 			}
 
@@ -463,7 +463,7 @@ namespace HitScoreVisualizer.Services
 					continue;
 				}
 
-				_siraLog.Warn($"Duplicate entry found for threshold {currentJudgment.Threshold} in {configName}");
+				siraLog.Warn($"Duplicate entry found for threshold {currentJudgment.Threshold} in {configName}");
 				return false;
 			}
 
@@ -473,12 +473,12 @@ namespace HitScoreVisualizer.Services
 		private void RunMigration(Configuration userConfig)
 		{
 			var userConfigVersion = userConfig.Version;
-			foreach (var requiredMigration in _migrationActions.Keys.Where(migrationVersion => migrationVersion >= userConfigVersion))
+			foreach (var requiredMigration in migrationActions.Keys.Where(migrationVersion => migrationVersion >= userConfigVersion))
 			{
-				_migrationActions[requiredMigration](userConfig);
+				migrationActions[requiredMigration](userConfig);
 			}
 
-			userConfig.Version = _pluginVersion;
+			userConfig.Version = pluginVersion;
 		}
 
 		private static bool RunMigration2_0_0(Configuration configuration)
@@ -532,14 +532,14 @@ namespace HitScoreVisualizer.Services
 
 		private bool CreateHsvConfigsFolderIfYeetedByPlayer(bool calledOnInit = true)
 		{
-			if (!Directory.Exists(_hsvConfigsFolderPath))
+			if (!Directory.Exists(hsvConfigsFolderPath))
 			{
 				if (!calledOnInit)
 				{
-					_siraLog.Warn("*sigh* Don't yeet the HSV configs folder while the game is running... Recreating it again...");
+					siraLog.Warn("*sigh* Don't yeet the HSV configs folder while the game is running... Recreating it again...");
 				}
 
-				Directory.CreateDirectory(_hsvConfigsFolderPath);
+				Directory.CreateDirectory(hsvConfigsFolderPath);
 
 				return true;
 			}

--- a/HitScoreVisualizer/Services/JudgmentService.cs
+++ b/HitScoreVisualizer/Services/JudgmentService.cs
@@ -28,12 +28,12 @@ namespace HitScoreVisualizer.Services
 			text.overflowMode = TextOverflowModes.Overflow;
 
 			// save in case we need to fade
-			var index = config.Judgments!.FindIndex(j => j.Threshold <= cutScoreBuffer.cutScore);
-			var judgment = index >= 0 ? config.Judgments[index] : Judgment.Default;
+			var index = config.NormalJudgments!.FindIndex(j => j.Threshold <= cutScoreBuffer.cutScore);
+			var judgment = index >= 0 ? config.NormalJudgments[index] : NormalJudgment.Default;
 
 			if (judgment.Fade)
 			{
-				var fadeJudgment = config.Judgments[index - 1];
+				var fadeJudgment = config.NormalJudgments[index - 1];
 				var baseColor = judgment.Color.ToColor();
 				var fadeColor = fadeJudgment.Color.ToColor();
 				var lerpDistance = Mathf.InverseLerp(judgment.Threshold, fadeJudgment.Threshold, cutScoreBuffer.cutScore);
@@ -55,7 +55,7 @@ namespace HitScoreVisualizer.Services
 		}
 
 		// ReSharper disable once CognitiveComplexity
-		private static string DisplayModeFormat(IReadonlyCutScoreBuffer cutScoreBuffer, Judgment judgment, Configuration instance)
+		private static string DisplayModeFormat(IReadonlyCutScoreBuffer cutScoreBuffer, NormalJudgment judgment, Configuration instance)
 		{
 			return cutScoreBuffer.noteCutInfo.noteData.gameplayType switch
 			{
@@ -65,7 +65,7 @@ namespace HitScoreVisualizer.Services
 			};
 		}
 
-		private static string NormalNoteJudgment(IReadonlyCutScoreBuffer cutScoreBuffer, Judgment judgment, Configuration instance)
+		private static string NormalNoteJudgment(IReadonlyCutScoreBuffer cutScoreBuffer, NormalJudgment judgment, Configuration instance)
 		{
 			var formattedBuilder = new StringBuilder();
 			var formatString = judgment.Text;

--- a/HitScoreVisualizer/Services/JudgmentService.cs
+++ b/HitScoreVisualizer/Services/JudgmentService.cs
@@ -7,18 +7,13 @@ using UnityEngine;
 
 namespace HitScoreVisualizer.Services
 {
-	internal class JudgmentService
+	internal class JudgmentService(ConfigProvider configProvider)
 	{
-		private readonly ConfigProvider _configProvider;
-
-		public JudgmentService(ConfigProvider configProvider)
-		{
-			_configProvider = configProvider;
-		}
+		private readonly ConfigProvider configProvider = configProvider;
 
 		internal void Judge(ref TextMeshPro text, ref Color color, CutScoreBuffer cutScoreBuffer)
 		{
-			var config = _configProvider.GetCurrentConfig();
+			var config = configProvider.GetCurrentConfig();
 			if (config == null)
 			{
 				return;

--- a/HitScoreVisualizer/Services/JudgmentService.cs
+++ b/HitScoreVisualizer/Services/JudgmentService.cs
@@ -6,10 +6,9 @@ using UnityEngine;
 
 namespace HitScoreVisualizer.Services
 {
-	internal class JudgmentService(ConfigProvider configProvider, SiraLog log)
+	internal class JudgmentService(ConfigProvider configProvider)
 	{
 		private readonly ConfigProvider configProvider = configProvider;
-		private readonly SiraLog log = log;
 
 		private Configuration Config => configProvider.CurrentConfig ?? Configuration.Default;
 

--- a/HitScoreVisualizer/Services/JudgmentService.cs
+++ b/HitScoreVisualizer/Services/JudgmentService.cs
@@ -19,25 +19,33 @@ namespace HitScoreVisualizer.Services
 				return;
 			}
 
-			var timeDependence = Mathf.Abs(cutScoreBuffer.noteCutInfo.cutNormal.z);
+			config.NormalJudgments ??= [];
 
-			// enable rich text
 			text.richText = true;
-			// disable word wrap, make sure full text displays
 			text.enableWordWrapping = false;
 			text.overflowMode = TextOverflowModes.Overflow;
 
-			// save in case we need to fade
-			var index = config.NormalJudgments!.FindIndex(j => j.Threshold <= cutScoreBuffer.cutScore);
-			var judgment = index >= 0 ? config.NormalJudgments[index] : NormalJudgment.Default;
+			NormalJudgment? judgment = null;
+			NormalJudgment? fadeJudgment = null;
+
+			for (var i = 0; i < config.NormalJudgments.Count; i++)
+			{
+				if (config.NormalJudgments[i].Threshold <= cutScoreBuffer.cutScore)
+				{
+					judgment = config.NormalJudgments[i];
+					fadeJudgment = i > 0
+						? config.NormalJudgments[i - 1]
+						: NormalJudgment.Default;
+				}
+			}
+
+			judgment ??= NormalJudgment.Default;
 
 			if (judgment.Fade)
 			{
-				var fadeJudgment = config.NormalJudgments[index - 1];
-				var baseColor = judgment.Color.ToColor();
-				var fadeColor = fadeJudgment.Color.ToColor();
+				fadeJudgment ??= NormalJudgment.Default;
 				var lerpDistance = Mathf.InverseLerp(judgment.Threshold, fadeJudgment.Threshold, cutScoreBuffer.cutScore);
-				color = Color.Lerp(baseColor, fadeColor, lerpDistance);
+				color = Color.Lerp(judgment.Color.ToColor(), fadeJudgment.Color.ToColor(), lerpDistance);
 			}
 			else
 			{

--- a/HitScoreVisualizer/Settings/ChainHeadJudgment.cs
+++ b/HitScoreVisualizer/Settings/ChainHeadJudgment.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace HitScoreVisualizer.Settings
+{
+	[method: JsonConstructor]
+	public class ChainHeadJudgment(int threshold = 0, string? text = null, List<float>? color = null, bool fade = false)
+	{
+		[JsonIgnore]
+		internal static ChainHeadJudgment Default { get; } = new();
+
+		// This judgment will be applied only to chain note heads hit with score >= this number.
+		// Note that if no judgment can be applied to a note, the text will appear as in the unmodded
+		// game.
+		[JsonProperty("threshold")]
+		public int Threshold { get; internal set; } = threshold;
+
+		// The text to display (if judgment text is enabled).
+		[JsonProperty("text")]
+		public string Text { get; internal set; } = text ?? string.Empty;
+
+		// 4 floats, 0-1; red, green, blue, glow (not transparency!)
+		// leaving this out should look obviously wrong
+		[JsonProperty("color")]
+		public List<float> Color { get; internal set; } = color ?? [];
+
+		// If true, the text color will be interpolated between this judgment's color and the previous
+		// based on how close to the next threshold it is.
+		// Specifying fade : true for the first judgment in the array is an error, and will crash the
+		// plugin.
+		[JsonProperty("fade")]
+		public bool Fade { get; internal set; } = fade;
+	}
+}

--- a/HitScoreVisualizer/Settings/ChainHeadJudgment.cs
+++ b/HitScoreVisualizer/Settings/ChainHeadJudgment.cs
@@ -4,31 +4,31 @@ using Newtonsoft.Json;
 namespace HitScoreVisualizer.Settings
 {
 	[method: JsonConstructor]
-	public class ChainHeadJudgment(int threshold = 0, string? text = null, List<float>? color = null, bool fade = false)
+	public readonly struct ChainHeadJudgment(int threshold = 0, string? text = null, List<float>? color = null, bool fade = false)
 	{
 		[JsonIgnore]
-		internal static ChainHeadJudgment Default { get; } = new();
+		internal static ChainHeadJudgment Default { get; } = new(0, "%s", [1, 1, 1, 1], false);
 
 		// This judgment will be applied only to chain note heads hit with score >= this number.
 		// Note that if no judgment can be applied to a note, the text will appear as in the unmodded
 		// game.
 		[JsonProperty("threshold")]
-		public int Threshold { get; internal set; } = threshold;
+		public int Threshold { get; } = threshold;
 
 		// The text to display (if judgment text is enabled).
 		[JsonProperty("text")]
-		public string Text { get; internal set; } = text ?? string.Empty;
+		public string Text { get; } = text ?? string.Empty;
 
 		// 4 floats, 0-1; red, green, blue, glow (not transparency!)
 		// leaving this out should look obviously wrong
 		[JsonProperty("color")]
-		public List<float> Color { get; internal set; } = color ?? [];
+		public List<float> Color { get; } = color ?? [0, 0, 0, 0];
 
 		// If true, the text color will be interpolated between this judgment's color and the previous
 		// based on how close to the next threshold it is.
 		// Specifying fade : true for the first judgment in the array is an error, and will crash the
 		// plugin.
 		[JsonProperty("fade")]
-		public bool Fade { get; internal set; } = fade;
+		public bool Fade { get; } = fade;
 	}
 }

--- a/HitScoreVisualizer/Settings/ChainLinkDisplay.cs
+++ b/HitScoreVisualizer/Settings/ChainLinkDisplay.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace HitScoreVisualizer.Settings
+{
+	[method: JsonConstructor]
+	public class ChainLinkDisplay(string? text = null, List<float>? color = null)
+	{
+		[JsonIgnore]
+		internal static ChainLinkDisplay Default { get; } = new();
+
+		// The text to display for a chain segment
+		[JsonProperty("text")]
+		public string? Text = text ?? string.Empty;
+
+		// 4 floats, 0-1; red, green, blue, glow (not transparency!)
+		// leaving this out should look obviously wrong
+		[JsonProperty("color")]
+		public List<float> Color = color ?? [];
+	}
+}

--- a/HitScoreVisualizer/Settings/ChainLinkDisplay.cs
+++ b/HitScoreVisualizer/Settings/ChainLinkDisplay.cs
@@ -4,18 +4,18 @@ using Newtonsoft.Json;
 namespace HitScoreVisualizer.Settings
 {
 	[method: JsonConstructor]
-	public class ChainLinkDisplay(string? text = null, List<float>? color = null)
+	public readonly struct ChainLinkDisplay(string? text = null, List<float>? color = null)
 	{
 		[JsonIgnore]
-		internal static ChainLinkDisplay Default { get; } = new();
+		internal static ChainLinkDisplay Default { get; } = new("<u>20", [1, 1, 1, 1]);
 
 		// The text to display for a chain segment
 		[JsonProperty("text")]
-		public string? Text = text ?? string.Empty;
+		public string Text { get; } = text ?? string.Empty;
 
 		// 4 floats, 0-1; red, green, blue, glow (not transparency!)
 		// leaving this out should look obviously wrong
 		[JsonProperty("color")]
-		public List<float> Color = color ?? [];
+		public List<float> Color { get; } = color ?? [0, 0, 0, 0];
 	}
 }

--- a/HitScoreVisualizer/Settings/Configuration.cs
+++ b/HitScoreVisualizer/Settings/Configuration.cs
@@ -19,18 +19,30 @@ namespace HitScoreVisualizer.Settings
 			DoIntermediateUpdates = true,
 			TimeDependenceDecimalPrecision = 1,
 			TimeDependenceDecimalOffset = 2,
-			Judgments = new List<Judgment>
-			{
-				new Judgment(threshold: 115, text: "%BFantastic%A%n%s", color: new List<float> { 1.0f, 1.0f, 1.0f, 1.0f }),
-				new Judgment(threshold: 101, text: "<size=80%>%BExcellent%A</size>%n%s", color: new List<float> { 0.0f, 1.0f, 0.0f, 1.0f }),
-				new Judgment(threshold: 90, text: "<size=80%>%BGreat%A</size>%n%s", color: new List<float> { 1.0f, 0.980392158f, 0.0f, 1.0f }),
-				new Judgment(threshold: 80, text: "<size=80%>%BGood%A</size>%n%s", color: new List<float> { 1.0f, 0.6f, 0.0f, 1.0f }, fade: true),
-				new Judgment(threshold: 60, text: "<size=80%>%BDecent%A</size>%n%s", color: new List<float> { 1.0f, 0.0f, 0.0f, 1.0f }, fade: true),
-				new Judgment(text: "<size=80%>%BWay Off%A</size>%n%s", color: new List<float> { 0.5f, 0.0f, 0.0f, 1.0f }, fade: true)
-			},
-			BeforeCutAngleJudgments = new List<JudgmentSegment> { new JudgmentSegment { Threshold = 70, Text = "+" }, new JudgmentSegment { Text = " " } },
-			AccuracyJudgments = new List<JudgmentSegment> { new JudgmentSegment { Threshold = 15, Text = " + " }, new JudgmentSegment { Text = " " } },
-			AfterCutAngleJudgments = new List<JudgmentSegment> { new JudgmentSegment { Threshold = 30, Text = " + " }, new JudgmentSegment { Text = " " } }
+			Judgments =
+			[
+				new(115, "%BFantastic%A%n%s", [1.0f, 1.0f, 1.0f, 1.0f]),
+				new(101, "<size=80%>%BExcellent%A</size>%n%s", [0.0f, 1.0f, 0.0f, 1.0f]),
+				new(90, "<size=80%>%BGreat%A</size>%n%s", [1.0f, 0.980392158f, 0.0f, 1.0f]),
+				new(80, "<size=80%>%BGood%A</size>%n%s", [1.0f, 0.6f, 0.0f, 1.0f], true),
+				new(60, "<size=80%>%BDecent%A</size>%n%s", [1.0f, 0.0f, 0.0f, 1.0f], true),
+				new(0, "<size=80%>%BWay Off%A</size>%n%s", [0.5f, 0.0f, 0.0f, 1.0f], true)
+			],
+			BeforeCutAngleJudgments =
+			[
+				new() { Threshold = 70, Text = "+" },
+				new() { Text = " " }
+			],
+			AccuracyJudgments =
+			[
+				new() { Threshold = 15, Text = " + " },
+				new() { Text = " " }
+			],
+			AfterCutAngleJudgments =
+			[
+				new() { Threshold = 30, Text = " + " },
+				new() { Text = " " }
+			]
 		};
 
 		// If the version number (excluding patch version) of the config is higher than that of the plugin,

--- a/HitScoreVisualizer/Settings/Configuration.cs
+++ b/HitScoreVisualizer/Settings/Configuration.cs
@@ -39,18 +39,18 @@ namespace HitScoreVisualizer.Settings
 			],
 			BeforeCutAngleJudgments =
 			[
-				new() { Threshold = 70, Text = "+" },
-				new() { Text = " " }
+				new(70, " + "),
+				new(0, " ")
 			],
 			AccuracyJudgments =
 			[
-				new() { Threshold = 15, Text = " + " },
-				new() { Text = " " }
+				new(15, " + "),
+				new(0, " ")
 			],
 			AfterCutAngleJudgments =
 			[
-				new() { Threshold = 30, Text = " + " },
-				new() { Text = " " }
+				new(30, " + "),
+				new(0, " ")
 			]
 		};
 

--- a/HitScoreVisualizer/Settings/Configuration.cs
+++ b/HitScoreVisualizer/Settings/Configuration.cs
@@ -54,10 +54,6 @@ namespace HitScoreVisualizer.Settings
 			]
 		};
 
-		// If the version number (excluding patch version) of the config is higher than that of the plugin,
-		// the config will not be loaded. If the version number of the config is lower than that of the
-		// plugin, the file will be automatically converted. Conversion is not guaranteed to occur, or be
-		// accurate, across major versions.
 		[JsonProperty("majorVersion", DefaultValueHandling = DefaultValueHandling.Include)]
 		public ulong MajorVersion { get; private set; } = Plugin.Version.Major;
 
@@ -79,26 +75,9 @@ namespace HitScoreVisualizer.Settings
 			}
 		}
 
-		// If this is true, the config will be overwritten with the plugin' default settings after an
-		// update rather than being converted.
 		[JsonProperty("isDefaultConfig")]
 		public bool IsDefaultConfig { get; internal set; }
 
-		// If set to "format", displays the judgment text, with the following format specifiers allowed:
-		// - %b: The score contributed by the part of the swing before cutting the block.
-		// - %c: The score contributed by the accuracy of the cut.
-		// - %a: The score contributed by the part of the swing after cutting the block.
-		// - %t: The time dependence of the swing
-		// - %B, %C, %A, %T: As above, except using the appropriate judgment from that part of the swing (as configured for "beforeCutAngleJudgments", "accuracyJudgments", "afterCutAngleJudgments", or "timeDependencyJudgments").
-		// - %s: The total score for the cut.
-		// - %p: The percent out of 115 you achieved with your swing's score
-		// - %%: A literal percent symbol.
-		// - %n: A newline.
-		//
-		// If set to "numeric", displays only the note score.
-		// If set to "textOnly", displays only the judgment text.
-		// If set to "scoreOnTop", displays both (numeric score above judgment text).
-		// Otherwise, displays both (judgment text above numeric score).
 		[JsonProperty("displayMode")]
 		[DefaultValue("")]
 		public string DisplayMode { get; internal set; } = string.Empty;
@@ -127,61 +106,41 @@ namespace HitScoreVisualizer.Settings
 		[Obsolete("Obsolete since 3.2.0. Use the FixedPosition property instead.")]
 		public float FixedPosZ { get; internal set; }
 
-		// If not null, judgments will appear and stay at rather than moving as normal, this will take priority over TargetPositionOffset.
-		// Additionally, the previous judgment will disappear when a new one is created (so there won't be overlap).
-		// Format changed to nullable Vector3 since version 3.2.0
 		[JsonProperty("fixedPosition", NullValueHandling = NullValueHandling.Ignore)]
 		public Vector3? FixedPosition { get; set; }
 
-		// Will offset the target position of the hitscore fade animation.
-		// If a fixed position is defined in the config, that one will take priority over this one and this will be fully ignored.
 		[JsonProperty("targetPositionOffset", NullValueHandling = NullValueHandling.Ignore)]
 		public Vector3? TargetPositionOffset { get; set; }
 
-		// If enabled, judgments will be updated more frequently. This will make score popups more accurate during a brief period before the note's score is finalized, at some cost of performance.
 		[JsonProperty("doIntermediateUpdates")]
 		public bool DoIntermediateUpdates { get; internal set; }
 
-		// Number of decimal places to show time dependence to
 		[JsonProperty("timeDependencyDecimalPrecision")]
 		[DefaultValue(1)]
 		public int TimeDependenceDecimalPrecision { get; internal set; }
 
-		// Which power of 10 to multiply the time dependence by
 		[JsonProperty("timeDependencyDecimalOffset")]
 		[DefaultValue(2)]
 		public int TimeDependenceDecimalOffset { get; internal set; }
 
-		// Order from highest threshold to lowest; the first matching judgment will be applied
 		[JsonProperty("judgments")]
 		public List<NormalJudgment>? NormalJudgments { get; internal set; }
 
-		// Same as normal judgments but for burst sliders aka. chain notes
 		[JsonProperty("chainHeadJudgments")]
 		public List<ChainHeadJudgment>? ChainHeadJudgments { get; internal set; }
 
-		// Text displayed for burst slider segments
 		[JsonProperty("chainLinkDisplay")]
 		public ChainLinkDisplay? ChainLinkDisplay { get; internal set; }
 
-		// Judgments for the part of the swing before cutting the block (score is from 0-70).
-		// Format specifier: %B
 		[JsonProperty("beforeCutAngleJudgments")]
 		public List<JudgmentSegment>? BeforeCutAngleJudgments { get; internal set; }
 
-
-		// Judgments for the accuracy of the cut (how close to the center of the block the cut was, score is from 0-15).
-		// Format specifier: %C
 		[JsonProperty("accuracyJudgments")]
 		public List<JudgmentSegment>? AccuracyJudgments { get; internal set; }
 
-		// Judgments for the part of the swing after cutting the block (score is from 0-30).
-		// Format specifier: %A
 		[JsonProperty("afterCutAngleJudgments")]
 		public List<JudgmentSegment>? AfterCutAngleJudgments { get; internal set; }
 
-		// Judgments for time dependence (score is from 0-1).
-		// Format specifier: %T
 		[JsonProperty("timeDependencyJudgments")]
 		public List<TimeDependenceJudgmentSegment>? TimeDependenceJudgments { get; internal set; }
 	}

--- a/HitScoreVisualizer/Settings/Configuration.cs
+++ b/HitScoreVisualizer/Settings/Configuration.cs
@@ -19,7 +19,7 @@ namespace HitScoreVisualizer.Settings
 			DoIntermediateUpdates = true,
 			TimeDependenceDecimalPrecision = 1,
 			TimeDependenceDecimalOffset = 2,
-			Judgments =
+			NormalJudgments =
 			[
 				new(115, "%BFantastic%A%n%s", [1.0f, 1.0f, 1.0f, 1.0f]),
 				new(101, "<size=80%>%BExcellent%A</size>%n%s", [0.0f, 1.0f, 0.0f, 1.0f]),
@@ -27,6 +27,15 @@ namespace HitScoreVisualizer.Settings
 				new(80, "<size=80%>%BGood%A</size>%n%s", [1.0f, 0.6f, 0.0f, 1.0f], true),
 				new(60, "<size=80%>%BDecent%A</size>%n%s", [1.0f, 0.0f, 0.0f, 1.0f], true),
 				new(0, "<size=80%>%BWay Off%A</size>%n%s", [0.5f, 0.0f, 0.0f, 1.0f], true)
+			],
+			ChainHeadJudgments =
+			[
+				new(115, "%BFantastic%n%s", [1.0f, 1.0f, 1.0f, 1.0f]),
+				new(101, "<size=80%>%BExcellent</size>%n%s", [0.0f, 1.0f, 0.0f, 1.0f]),
+				new(90, "<size=80%>%BGreat</size>%n%s", [1.0f, 0.980392158f, 0.0f, 1.0f]),
+				new(80, "<size=80%>%BGood</size>%n%s", [1.0f, 0.6f, 0.0f, 1.0f], true),
+				new(60, "<size=80%>%BDecent</size>%n%s", [1.0f, 0.0f, 0.0f, 1.0f], true),
+				new(0, "<size=80%>%BWay Off</size>%n%s", [0.5f, 0.0f, 0.0f, 1.0f], true)
 			],
 			BeforeCutAngleJudgments =
 			[
@@ -61,7 +70,7 @@ namespace HitScoreVisualizer.Settings
 		[JsonIgnore]
 		internal Version Version
 		{
-			get => new Version(MajorVersion, MinorVersion, PatchVersion);
+			get => new(MajorVersion, MinorVersion, PatchVersion);
 			set
 			{
 				MajorVersion = value.Major;
@@ -145,7 +154,15 @@ namespace HitScoreVisualizer.Settings
 
 		// Order from highest threshold to lowest; the first matching judgment will be applied
 		[JsonProperty("judgments")]
-		public List<Judgment>? Judgments { get; internal set; }
+		public List<NormalJudgment>? NormalJudgments { get; internal set; }
+
+		// Same as normal judgments but for burst sliders aka. chain notes
+		[JsonProperty("chainHeadJudgments")]
+		public List<ChainHeadJudgment>? ChainHeadJudgments { get; internal set; }
+
+		// Text displayed for burst slider segments
+		[JsonProperty("chainLinkDisplay")]
+		public ChainLinkDisplay? ChainLinkDisplay { get; internal set; }
 
 		// Judgments for the part of the swing before cutting the block (score is from 0-70).
 		// Format specifier: %B

--- a/HitScoreVisualizer/Settings/HSVConfig.cs
+++ b/HitScoreVisualizer/Settings/HSVConfig.cs
@@ -8,5 +8,6 @@ namespace HitScoreVisualizer.Settings
 	{
 		public virtual string? ConfigFilePath { get; set; }
 		public virtual bool HitScoreBloom { get; set; }
+		public virtual bool EnableItalics { get; set; } = true;
 	}
 }

--- a/HitScoreVisualizer/Settings/Judgment.cs
+++ b/HitScoreVisualizer/Settings/Judgment.cs
@@ -3,40 +3,32 @@ using Newtonsoft.Json;
 
 namespace HitScoreVisualizer.Settings
 {
-	public class Judgment
+	[method: JsonConstructor]
+	public class Judgment(int threshold = 0, string? text = null, List<float>? color = null, bool fade = false)
 	{
 		[JsonIgnore]
-		internal static Judgment Default { get; } = new Judgment {Threshold = 0, Text = string.Empty, Color = new List<float> {1f, 1f, 1f, 1f}, Fade = false};
+		internal static Judgment Default { get; } = new();
 
 		// This judgment will be applied only to notes hit with score >= this number.
 		// Note that if no judgment can be applied to a note, the text will appear as in the unmodded
 		// game.
 		[JsonProperty("threshold")]
-		public int Threshold { get; internal set; }
+		public int Threshold { get; internal set; } = threshold;
 
 		// The text to display (if judgment text is enabled).
 		[JsonProperty("text")]
-		public string Text { get; internal set; }
+		public string Text { get; internal set; } = text ?? string.Empty;
 
 		// 4 floats, 0-1; red, green, blue, glow (not transparency!)
 		// leaving this out should look obviously wrong
 		[JsonProperty("color")]
-		public List<float> Color { get; internal set; }
+		public List<float> Color { get; internal set; } = color ?? [1f, 1f, 1f, 1f];
 
 		// If true, the text color will be interpolated between this judgment's color and the previous
 		// based on how close to the next threshold it is.
 		// Specifying fade : true for the first judgment in the array is an error, and will crash the
 		// plugin.
 		[JsonProperty("fade")]
-		public bool Fade { get; internal set; }
-
-		[JsonConstructor]
-		internal Judgment(int threshold = 0, string? text = null, List<float>? color = null, bool fade = false)
-		{
-			Threshold = threshold;
-			Text = text ?? string.Empty;
-			Color = color ?? new List<float>();
-			Fade = fade;
-		}
+		public bool Fade { get; internal set; } = fade;
 	}
 }

--- a/HitScoreVisualizer/Settings/JudgmentSegment.cs
+++ b/HitScoreVisualizer/Settings/JudgmentSegment.cs
@@ -1,19 +1,20 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace HitScoreVisualizer.Settings
 {
-	public class JudgmentSegment
+	[method: JsonConstructor]
+	public class JudgmentSegment(int threshold = 0, string? text = null)
 	{
 		[JsonIgnore]
-		internal static JudgmentSegment Default { get; } = new JudgmentSegment {Threshold = 0, Text = string.Empty};
+		internal static JudgmentSegment Default { get; } = new();
 
 		// This judgment will be applied only when the appropriate part of the swing contributes score >= this number.
 		// If no judgment can be applied, the judgment for this segment will be "" (the empty string).
 		[JsonProperty("threshold")]
-		public int Threshold { get; internal set; }
+		public int Threshold { get; internal set; } = threshold;
 
 		// The text to replace the appropriate judgment specifier with (%B, %C, %A) when this judgment applies.
 		[JsonProperty("text")]
-		public string? Text { get; internal set; }
+		public string? Text { get; internal set; } = text ?? string.Empty;
 	}
 }

--- a/HitScoreVisualizer/Settings/JudgmentSegment.cs
+++ b/HitScoreVisualizer/Settings/JudgmentSegment.cs
@@ -3,18 +3,18 @@ using Newtonsoft.Json;
 namespace HitScoreVisualizer.Settings
 {
 	[method: JsonConstructor]
-	public class JudgmentSegment(int threshold = 0, string? text = null)
+	public readonly struct JudgmentSegment(int threshold = 0, string? text = null)
 	{
 		[JsonIgnore]
-		internal static JudgmentSegment Default { get; } = new();
+		internal static JudgmentSegment Default { get; } = new(0, string.Empty);
 
 		// This judgment will be applied only when the appropriate part of the swing contributes score >= this number.
 		// If no judgment can be applied, the judgment for this segment will be "" (the empty string).
 		[JsonProperty("threshold")]
-		public int Threshold { get; internal set; } = threshold;
+		public int Threshold { get; } = threshold;
 
 		// The text to replace the appropriate judgment specifier with (%B, %C, %A) when this judgment applies.
 		[JsonProperty("text")]
-		public string? Text { get; internal set; } = text ?? string.Empty;
+		public string? Text { get; } = text ?? string.Empty;
 	}
 }

--- a/HitScoreVisualizer/Settings/NormalJudgment.cs
+++ b/HitScoreVisualizer/Settings/NormalJudgment.cs
@@ -4,31 +4,31 @@ using Newtonsoft.Json;
 namespace HitScoreVisualizer.Settings
 {
 	[method: JsonConstructor]
-	public class NormalJudgment(int threshold = 0, string? text = null, List<float>? color = null, bool fade = false)
+	public readonly struct NormalJudgment(int threshold = 0, string? text = null, List<float>? color = null, bool fade = false)
 	{
 		[JsonIgnore]
-		internal static NormalJudgment Default { get; } = new();
+		internal static NormalJudgment Default { get; } = new(0, "%s", [1, 1, 1, 1], false);
 
 		// This judgment will be applied only to normal notes hit with score >= this number.
 		// Note that if no judgment can be applied to a note, the text will appear as in the unmodded
 		// game.
 		[JsonProperty("threshold")]
-		public int Threshold { get; internal set; } = threshold;
+		public int Threshold { get; } = threshold;
 
 		// The text to display (if judgment text is enabled).
 		[JsonProperty("text")]
-		public string Text { get; internal set; } = text ?? string.Empty;
+		public string Text { get; } = text ?? string.Empty;
 
 		// 4 floats, 0-1; red, green, blue, glow (not transparency!)
 		// leaving this out should look obviously wrong
 		[JsonProperty("color")]
-		public List<float> Color { get; internal set; } = color ?? [];
+		public List<float> Color { get; } = color ?? [0, 0, 0, 0];
 
 		// If true, the text color will be interpolated between this judgment's color and the previous
 		// based on how close to the next threshold it is.
 		// Specifying fade : true for the first judgment in the array is an error, and will crash the
 		// plugin.
 		[JsonProperty("fade")]
-		public bool Fade { get; internal set; } = fade;
+		public bool Fade { get; } = fade;
 	}
 }

--- a/HitScoreVisualizer/Settings/NormalJudgment.cs
+++ b/HitScoreVisualizer/Settings/NormalJudgment.cs
@@ -4,12 +4,12 @@ using Newtonsoft.Json;
 namespace HitScoreVisualizer.Settings
 {
 	[method: JsonConstructor]
-	public class Judgment(int threshold = 0, string? text = null, List<float>? color = null, bool fade = false)
+	public class NormalJudgment(int threshold = 0, string? text = null, List<float>? color = null, bool fade = false)
 	{
 		[JsonIgnore]
-		internal static Judgment Default { get; } = new();
+		internal static NormalJudgment Default { get; } = new();
 
-		// This judgment will be applied only to notes hit with score >= this number.
+		// This judgment will be applied only to normal notes hit with score >= this number.
 		// Note that if no judgment can be applied to a note, the text will appear as in the unmodded
 		// game.
 		[JsonProperty("threshold")]
@@ -22,7 +22,7 @@ namespace HitScoreVisualizer.Settings
 		// 4 floats, 0-1; red, green, blue, glow (not transparency!)
 		// leaving this out should look obviously wrong
 		[JsonProperty("color")]
-		public List<float> Color { get; internal set; } = color ?? [1f, 1f, 1f, 1f];
+		public List<float> Color { get; internal set; } = color ?? [];
 
 		// If true, the text color will be interpolated between this judgment's color and the previous
 		// based on how close to the next threshold it is.

--- a/HitScoreVisualizer/Settings/TimeDependenceJudgmentSegment.cs
+++ b/HitScoreVisualizer/Settings/TimeDependenceJudgmentSegment.cs
@@ -3,18 +3,18 @@ using Newtonsoft.Json;
 namespace HitScoreVisualizer.Settings
 {
 	[method: JsonConstructor]
-	public class TimeDependenceJudgmentSegment(float threshold = 0f, string? text = null)
+	public readonly struct TimeDependenceJudgmentSegment(float threshold = 0f, string? text = null)
 	{
 		[JsonIgnore]
-		internal static TimeDependenceJudgmentSegment Default { get; } = new();
+		internal static TimeDependenceJudgmentSegment Default { get; } = new(0, string.Empty);
 
 		// This judgment will be applied only when the time dependence >= this number.
 		// If no judgment can be applied, the judgment for this segment will be "" (the empty string).
 		[JsonProperty("threshold")]
-		public float Threshold { get; internal set; } = threshold;
+		public float Threshold { get; } = threshold;
 
 		// The text to replace the appropriate judgment specifier with (%T) when this judgment applies.
 		[JsonProperty("text")]
-		public string? Text { get; internal set; } = text ?? string.Empty;
+		public string? Text { get; } = text ?? string.Empty;
 	}
 }

--- a/HitScoreVisualizer/Settings/TimeDependenceJudgmentSegment.cs
+++ b/HitScoreVisualizer/Settings/TimeDependenceJudgmentSegment.cs
@@ -2,18 +2,19 @@ using Newtonsoft.Json;
 
 namespace HitScoreVisualizer.Settings
 {
-	public class TimeDependenceJudgmentSegment
+	[method: JsonConstructor]
+	public class TimeDependenceJudgmentSegment(float threshold = 0f, string? text = null)
 	{
 		[JsonIgnore]
-		internal static TimeDependenceJudgmentSegment Default { get; } = new TimeDependenceJudgmentSegment { Threshold = 0, Text = string.Empty };
+		internal static TimeDependenceJudgmentSegment Default { get; } = new();
 
 		// This judgment will be applied only when the time dependence >= this number.
 		// If no judgment can be applied, the judgment for this segment will be "" (the empty string).
 		[JsonProperty("threshold")]
-		public float Threshold { get; internal set; }
+		public float Threshold { get; internal set; } = threshold;
 
 		// The text to replace the appropriate judgment specifier with (%T) when this judgment applies.
 		[JsonProperty("text")]
-		public string? Text { get; internal set; }
+		public string? Text { get; internal set; } = text ?? string.Empty;
 	}
 }

--- a/HitScoreVisualizer/UI/ConfigSelectorViewController.cs
+++ b/HitScoreVisualizer/UI/ConfigSelectorViewController.cs
@@ -63,7 +63,10 @@ namespace HitScoreVisualizer.UI
 		internal bool CanConfigGetYeeted => _selectedConfigFileInfo?.ConfigPath != null && _selectedConfigFileInfo.ConfigPath != _configProvider.CurrentConfigPath;
 
 		[UIValue("bloom-toggle-face-color")]
-		internal string BloomToggleFaceColor => _hsvConfig.HitScoreBloom ? "#22dd00" : "#ff0045";
+		internal string BloomToggleFaceColor => _hsvConfig.HitScoreBloom ? "#22dd00" : "#ff0010";
+
+		[UIValue("italics-toggle-face-color")]
+		internal string ItalicsToggleFaceColor => _hsvConfig.EnableItalics ? "#22dd00" : "#ff0010";
 
 		[UIAction("config-Selected")]
 		internal void Select(TableView _, object @object)
@@ -116,6 +119,13 @@ namespace HitScoreVisualizer.UI
 		{
 			_hsvConfig.HitScoreBloom = !_hsvConfig.HitScoreBloom;
 			NotifyPropertyChanged(nameof(BloomToggleFaceColor));
+		}
+
+		[UIAction("toggle-italics")]
+		internal void ToggleItalics()
+		{
+			_hsvConfig.EnableItalics = !_hsvConfig.EnableItalics;
+			NotifyPropertyChanged(nameof(ItalicsToggleFaceColor));
 		}
 
 		[UIAction("yeet-config")]

--- a/HitScoreVisualizer/UI/ConfigSelectorViewController.cs
+++ b/HitScoreVisualizer/UI/ConfigSelectorViewController.cs
@@ -19,30 +19,25 @@ namespace HitScoreVisualizer.UI
 	[ViewDefinition("HitScoreVisualizer.UI.Views.ConfigSelector.bsml")]
 	internal class ConfigSelectorViewController : BSMLAutomaticViewController
 	{
-		private SiraLog _siraLog = null!;
-		private ConfigProvider _configProvider = null!;
-		private HSVConfig _hsvConfig = null!;
+		private SiraLog siraLog = null!;
+		private ConfigProvider configProvider = null!;
+		private HSVConfig hsvConfig = null!;
 
-		private ConfigFileInfo? _selectedConfigFileInfo;
-
-		public ConfigSelectorViewController()
-		{
-			AvailableConfigs = new List<object>();
-		}
+		private ConfigFileInfo? selectedConfigFileInfo;
 
 		[Inject]
 		internal void Construct(SiraLog siraLog, HSVConfig hsvConfig, ConfigProvider configProvider)
 		{
-			_siraLog = siraLog;
-			_hsvConfig = hsvConfig;
-			_configProvider = configProvider;
+			this.siraLog = siraLog;
+			this.hsvConfig = hsvConfig;
+			this.configProvider = configProvider;
 		}
 
 		[UIComponent("configs-list")]
 		public CustomCellListTableData? customListTableData;
 
 		[UIValue("available-configs")]
-		internal List<object> AvailableConfigs { get; }
+		internal List<object> AvailableConfigs { get; } = [];
 
 		[UIValue("loading-available-configs")]
 		internal bool LoadingConfigs { get; private set; }
@@ -51,27 +46,27 @@ namespace HitScoreVisualizer.UI
 		internal bool HasLoadedConfigs => !LoadingConfigs;
 
 		[UIValue("is-valid-config-selected")]
-		internal bool CanConfigGetSelected => _selectedConfigFileInfo?.ConfigPath != _configProvider.CurrentConfigPath && ConfigProvider.ConfigSelectable(_selectedConfigFileInfo?.State);
+		internal bool CanConfigGetSelected => selectedConfigFileInfo?.ConfigPath != configProvider.CurrentConfigPath && ConfigProvider.ConfigSelectable(selectedConfigFileInfo?.State);
 
 		[UIValue("has-config-loaded")]
-		internal bool HasConfigCurrently => !string.IsNullOrWhiteSpace(_configProvider.CurrentConfigPath);
+		internal bool HasConfigCurrently => !string.IsNullOrWhiteSpace(configProvider.CurrentConfigPath);
 
 		[UIValue("config-loaded-text")]
-		internal string LoadedConfigText => $"Currently loaded config: <size=80%>{(HasConfigCurrently ? Path.GetFileNameWithoutExtension(_configProvider.CurrentConfigPath) : "None")}";
+		internal string LoadedConfigText => $"Currently loaded config: <size=80%>{(HasConfigCurrently ? Path.GetFileNameWithoutExtension(configProvider.CurrentConfigPath) : "None")}";
 
 		[UIValue("is-config-yeetable")]
-		internal bool CanConfigGetYeeted => _selectedConfigFileInfo?.ConfigPath != null && _selectedConfigFileInfo.ConfigPath != _configProvider.CurrentConfigPath;
+		internal bool CanConfigGetYeeted => selectedConfigFileInfo?.ConfigPath != null && selectedConfigFileInfo.ConfigPath != configProvider.CurrentConfigPath;
 
 		[UIValue("bloom-toggle-face-color")]
-		internal string BloomToggleFaceColor => _hsvConfig.HitScoreBloom ? "#22dd00" : "#ff0010";
+		internal string BloomToggleFaceColor => hsvConfig.HitScoreBloom ? "#22dd00" : "#ff0010";
 
 		[UIValue("italics-toggle-face-color")]
-		internal string ItalicsToggleFaceColor => _hsvConfig.EnableItalics ? "#22dd00" : "#ff0010";
+		internal string ItalicsToggleFaceColor => hsvConfig.EnableItalics ? "#22dd00" : "#ff0010";
 
 		[UIAction("config-Selected")]
 		internal void Select(TableView _, object @object)
 		{
-			_selectedConfigFileInfo = (ConfigFileInfo)@object;
+			selectedConfigFileInfo = (ConfigFileInfo)@object;
 			NotifyPropertyChanged(nameof(CanConfigGetSelected));
 			NotifyPropertyChanged(nameof(CanConfigGetYeeted));
 		}
@@ -85,9 +80,9 @@ namespace HitScoreVisualizer.UI
 		[UIAction("pick-config")]
 		internal async void PickConfig()
 		{
-			if (CanConfigGetSelected && _selectedConfigFileInfo != null)
+			if (CanConfigGetSelected && selectedConfigFileInfo != null)
 			{
-				await _configProvider.SelectUserConfig(_selectedConfigFileInfo).ConfigureAwait(false);
+				await configProvider.SelectUserConfig(selectedConfigFileInfo).ConfigureAwait(false);
 				await LoadInternal().ConfigureAwait(false);
 			}
 		}
@@ -101,14 +96,14 @@ namespace HitScoreVisualizer.UI
 				{
 					if (customListTableData == null)
 					{
-						_siraLog.Warn($"{nameof(customListTableData)} is null.");
+						siraLog.Warn($"{nameof(customListTableData)} is null.");
 						return;
 					}
 
 					customListTableData.tableView.ClearSelection();
 				});
 
-				_configProvider.UnselectUserConfig();
+				configProvider.UnselectUserConfig();
 				NotifyPropertyChanged(nameof(HasConfigCurrently));
 				NotifyPropertyChanged(nameof(LoadedConfigText));
 			}
@@ -117,14 +112,14 @@ namespace HitScoreVisualizer.UI
 		[UIAction("toggle-bloom-effect")]
 		internal void ToggleBloomEffect()
 		{
-			_hsvConfig.HitScoreBloom = !_hsvConfig.HitScoreBloom;
+			hsvConfig.HitScoreBloom = !hsvConfig.HitScoreBloom;
 			NotifyPropertyChanged(nameof(BloomToggleFaceColor));
 		}
 
 		[UIAction("toggle-italics")]
 		internal void ToggleItalics()
 		{
-			_hsvConfig.EnableItalics = !_hsvConfig.EnableItalics;
+			hsvConfig.EnableItalics = !hsvConfig.EnableItalics;
 			NotifyPropertyChanged(nameof(ItalicsToggleFaceColor));
 		}
 
@@ -136,7 +131,7 @@ namespace HitScoreVisualizer.UI
 				return;
 			}
 
-			_configProvider.YeetConfig(_selectedConfigFileInfo!.ConfigPath);
+			configProvider.YeetConfig(selectedConfigFileInfo!.ConfigPath);
 			await LoadInternal().ConfigureAwait(false);
 
 			NotifyPropertyChanged(nameof(CanConfigGetYeeted));
@@ -155,14 +150,14 @@ namespace HitScoreVisualizer.UI
 
 			AvailableConfigs.Clear();
 
-			_selectedConfigFileInfo = null;
+			selectedConfigFileInfo = null;
 		}
 
 		private async Task LoadInternal()
 		{
 			if (customListTableData == null)
 			{
-				_siraLog.Warn($"{nameof(customListTableData)} is null.");
+				siraLog.Warn($"{nameof(customListTableData)} is null.");
 				return;
 			}
 
@@ -175,13 +170,13 @@ namespace HitScoreVisualizer.UI
 			NotifyPropertyChanged(nameof(LoadingConfigs));
 			NotifyPropertyChanged(nameof(HasLoadedConfigs));
 
-			var intermediateConfigs = (await _configProvider.ListAvailableConfigs())
+			var intermediateConfigs = (await configProvider.ListAvailableConfigs())
 				.OrderByDescending(x => x.State)
 				.ThenBy(x => x.ConfigName)
 				.ToList();
 			AvailableConfigs.AddRange(intermediateConfigs);
 
-			var currentConfigIndex = intermediateConfigs.FindIndex(x => x.ConfigPath == _configProvider.CurrentConfigPath);
+			var currentConfigIndex = intermediateConfigs.FindIndex(x => x.ConfigPath == configProvider.CurrentConfigPath);
 
 			await UnityMainThreadTaskScheduler.Factory.StartNew(() =>
 			{

--- a/HitScoreVisualizer/UI/HitScoreFlowCoordinator.cs
+++ b/HitScoreVisualizer/UI/HitScoreFlowCoordinator.cs
@@ -1,4 +1,4 @@
-﻿using BeatSaberMarkupLanguage;
+using BeatSaberMarkupLanguage;
 using HMUI;
 using IPA.Loader;
 using SiraUtil.Zenject;
@@ -8,24 +8,24 @@ namespace HitScoreVisualizer.UI
 {
 	internal class HitScoreFlowCoordinator : FlowCoordinator
 	{
-		private string _pluginName = null!;
-		private ConfigSelectorViewController _configSelectorViewController = null!;
+		private string pluginName = null!;
+		private ConfigSelectorViewController configSelectorViewController = null!;
 
 		[Inject]
 		internal void Construct(UBinder<Plugin, PluginMetadata> pluginMetadata, ConfigSelectorViewController configSelectorViewController)
 		{
-			_pluginName = pluginMetadata.Value.Name;
-			_configSelectorViewController = configSelectorViewController;
+			pluginName = pluginMetadata.Value.Name;
+			this.configSelectorViewController = configSelectorViewController;
 		}
 
 		protected override void DidActivate(bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling)
 		{
 			if (firstActivation)
 			{
-				SetTitle(_pluginName);
+				SetTitle(pluginName);
 				showBackButton = true;
 
-				ProvideInitialViewControllers(_configSelectorViewController);
+				ProvideInitialViewControllers(configSelectorViewController);
 			}
 		}
 

--- a/HitScoreVisualizer/UI/SettingsControllerManager.cs
+++ b/HitScoreVisualizer/UI/SettingsControllerManager.cs
@@ -7,44 +7,39 @@ using Zenject;
 
 namespace HitScoreVisualizer.UI
 {
-	internal class SettingsControllerManager : IInitializable, IDisposable
+	internal class SettingsControllerManager(UBinder<Plugin, PluginMetadata> pluginMetadata, HitScoreFlowCoordinator hitScoreFlowCoordinator) : IInitializable, IDisposable
 	{
-		private readonly HitScoreFlowCoordinator _hitScoreFlowCoordinator;
+		private readonly HitScoreFlowCoordinator hitScoreFlowCoordinator = hitScoreFlowCoordinator;
+		private readonly PluginMetadata pluginMetadata = pluginMetadata.Value;
 
-		private MenuButton? _hsvButton;
-
-		public SettingsControllerManager(UBinder<Plugin, PluginMetadata> pluginMetadata, HitScoreFlowCoordinator hitScoreFlowCoordinator)
-		{
-			_hitScoreFlowCoordinator = hitScoreFlowCoordinator;
-
-			_hsvButton = new MenuButton($"<size=89.5%>{pluginMetadata.Value.Name}", "Select the config you want.", OnClick);
-		}
+		private MenuButton hsvButton = null!;
 
 		public void Initialize()
 		{
-			MenuButtons.instance.RegisterButton(_hsvButton);
+			hsvButton = new MenuButton($"<size=89.5%>{pluginMetadata.Name}", "Select the config you want.", OnClick);
+			MenuButtons.instance.RegisterButton(hsvButton);
 		}
 
 		private void OnClick()
 		{
-			if (_hitScoreFlowCoordinator == null)
+			if (hitScoreFlowCoordinator == null)
 			{
 				return;
 			}
 
-			BeatSaberUI.MainFlowCoordinator.PresentFlowCoordinator(_hitScoreFlowCoordinator);
+			BeatSaberUI.MainFlowCoordinator.PresentFlowCoordinator(hitScoreFlowCoordinator);
 		}
 
 		public void Dispose()
 		{
-			if (_hsvButton == null)
+			if (hsvButton == null)
 			{
 				return;
 			}
 
-			MenuButtons.instance.UnregisterButton(_hsvButton);
+			MenuButtons.instance.UnregisterButton(hsvButton);
 
-			_hsvButton = null!;
+			hsvButton = null!;
 		}
 	}
 }

--- a/HitScoreVisualizer/UI/Views/ConfigSelector.bsml
+++ b/HitScoreVisualizer/UI/Views/ConfigSelector.bsml
@@ -83,6 +83,13 @@
 						text="HitScore Bloom"
 						hover-hint="Toggles the bloom effect on HitScores."
 						on-click="toggle-bloom-effect"/>
+
+				<button pref-width="28"
+						word-wrapping="false"
+						face-color="~italics-toggle-face-color"
+						text="Font Italics"
+						hover-hint="Toggles the italicized text on HitScores"
+						on-click="toggle-italics"/>
 			</vertical>
 
 


### PR DESCRIPTION
- Added a button to toggle score effect's italics #11 
- Added judgments for chain head notes. These work the way that normal judgments work but are only applied when a chain is cut. Example below
```json
"chainHeadJudgments":[
  { "threshold": 85, "text": "<size=250%><b>•", "color": [1, 1, 1, 1] },
  { "threshold": 78, "text": "<size=120%>%B%c", "color": [1, 1, 1, 1] },
  { "threshold": 0, "text": "<size=120%><alpha=#88>%B%c", "color": [1, 1, 1, 1] }
]
```
- Added configuration of chain segment (aka. chain links) display. Example below
```json
"chainLinkDisplay": {
  "text": "<alpha=#66>%s",
  "color": [1, 1, 1, 1]
}
```
- The mod will now only attempt to load `.json` files in the configs folder
- Some minor optimizations