### PR TITLE
Custom miss and badcut text

### DIFF
--- a/HitScoreVisualizer/Components/HsvFlyingEffect.cs
+++ b/HitScoreVisualizer/Components/HsvFlyingEffect.cs
@@ -1,0 +1,56 @@
+using HitScoreVisualizer.Models;
+using TMPro;
+using UnityEngine;
+using Zenject;
+
+namespace HitScoreVisualizer.Components;
+
+internal class HsvFlyingEffect : FlyingObjectEffect
+{
+	public class Pool : MonoMemoryPool<HsvFlyingEffect>;
+
+	private AnimationCurve fadeAnimationCurve = null!;
+
+	[Inject]
+	public void Init(FlyingTextEffectAnimationData animationData)
+	{
+		fadeAnimationCurve = animationData.Fade;
+		_moveAnimationCurve = animationData.Move;
+	}
+
+	[SerializeField] public TextMeshPro? textMesh;
+
+	private Color color;
+
+	public void InitAndPresent(string text, float duration, Vector3 targetPos, Quaternion rotation, Color color, float fontSize, bool shake)
+	{
+		if (textMesh == null)
+		{
+			return;
+		}
+
+		this.color = color;
+		textMesh.text = text;
+		textMesh.fontSize = fontSize;
+		InitAndPresent(duration, targetPos, rotation, shake);
+	}
+
+	public override void ManualUpdate(float t)
+	{
+		if (textMesh != null)
+		{
+			textMesh.color = color with { a = fadeAnimationCurve.Evaluate(t) };
+		}
+	}
+
+	public static HsvFlyingEffect CreatePrefab()
+	{
+		var effect = new GameObject(nameof(HsvFlyingEffect)).AddComponent<HsvFlyingEffect>();
+		var textObject = new GameObject("Text") { layer = LayerMask.NameToLayer("UI") };
+		effect.textMesh = textObject.AddComponent<TextMeshPro>();
+		effect.textMesh.alignment = TextAlignmentOptions.Capline;
+		effect.textMesh.fontStyle = FontStyles.Bold | FontStyles.Italic;
+		textObject.transform.SetParent(effect.gameObject.transform, false);
+		return effect;
+	}
+}

--- a/HitScoreVisualizer/Components/HsvFlyingEffectSpawner.cs
+++ b/HitScoreVisualizer/Components/HsvFlyingEffectSpawner.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+using Zenject;
+
+namespace HitScoreVisualizer.Components;
+
+internal class HsvFlyingEffectSpawner : MonoBehaviour, IFlyingObjectEffectDidFinishEvent
+{
+	public record InitData(float Duration, float XSpread, float TargetYPos, float TargetZPos, Color Color, float FontSize);
+
+	private float duration;
+	private float xSpread;
+	private float targetYPos;
+	private float targetZPos;
+	private Color color;
+	private float fontSize;
+	private HsvFlyingEffect.Pool missTextEffectPool = null!;
+	private PluginConfig pluginConfig = null!;
+
+	[Inject]
+	public void Init(InitData initData, HsvFlyingEffect.Pool effectPool, PluginConfig config)
+	{
+		duration = initData.Duration;
+		xSpread = initData.XSpread;
+		targetYPos = initData.TargetYPos;
+		targetZPos = initData.TargetZPos;
+		color = initData.Color;
+		fontSize = initData.FontSize;
+		missTextEffectPool = effectPool;
+		pluginConfig = config;
+	}
+
+	public void SpawnText(Vector3 pos, Quaternion rotation, Quaternion inverseRotation, string text)
+	{
+		var missTextEffect = missTextEffectPool.Spawn();
+		missTextEffect.didFinishEvent.Add(this);
+		missTextEffect.transform.localPosition = pos;
+
+		var targetPos = rotation * new Vector3(Mathf.Sign((inverseRotation * pos).x) * xSpread, targetYPos, targetZPos);
+
+		missTextEffect.InitAndPresent(text, duration, targetPos, rotation, color, fontSize, false);
+	}
+
+	public void HandleFlyingObjectEffectDidFinish(FlyingObjectEffect flyingObjectEffect)
+	{
+		flyingObjectEffect.didFinishEvent.Remove(this);
+		missTextEffectPool.Despawn((HsvFlyingEffect)flyingObjectEffect);
+	}
+}

--- a/HitScoreVisualizer/Components/HsvFlyingEffectSpawner.cs
+++ b/HitScoreVisualizer/Components/HsvFlyingEffectSpawner.cs
@@ -29,7 +29,7 @@ internal class HsvFlyingEffectSpawner : MonoBehaviour, IFlyingObjectEffectDidFin
 		pluginConfig = config;
 	}
 
-	public void SpawnText(Vector3 pos, Quaternion rotation, Quaternion inverseRotation, string text)
+	public void SpawnText(Vector3 pos, Quaternion rotation, Quaternion inverseRotation, string text, Color? color)
 	{
 		var missTextEffect = missTextEffectPool.Spawn();
 		missTextEffect.didFinishEvent.Add(this);
@@ -37,7 +37,7 @@ internal class HsvFlyingEffectSpawner : MonoBehaviour, IFlyingObjectEffectDidFin
 
 		var targetPos = rotation * new Vector3(Mathf.Sign((inverseRotation * pos).x) * xSpread, targetYPos, targetZPos);
 
-		missTextEffect.InitAndPresent(text, duration, targetPos, rotation, color, fontSize, false);
+		missTextEffect.InitAndPresent(text, duration, targetPos, rotation, color ?? this.color, fontSize, false);
 	}
 
 	public void HandleFlyingObjectEffectDidFinish(FlyingObjectEffect flyingObjectEffect)

--- a/HitScoreVisualizer/HarmonyPatches/BadNoteCutEffectSpawnerPatch.cs
+++ b/HitScoreVisualizer/HarmonyPatches/BadNoteCutEffectSpawnerPatch.cs
@@ -1,10 +1,9 @@
+using System;
 using System.Linq;
 using HitScoreVisualizer.Components;
 using HitScoreVisualizer.Models;
 using HitScoreVisualizer.Utilities.Extensions;
 using SiraUtil.Affinity;
-using UnityEngine;
-using Random = System.Random;
 
 namespace HitScoreVisualizer.HarmonyPatches;
 

--- a/HitScoreVisualizer/HarmonyPatches/BadNoteCutEffectSpawnerPatch.cs
+++ b/HitScoreVisualizer/HarmonyPatches/BadNoteCutEffectSpawnerPatch.cs
@@ -1,0 +1,43 @@
+using HitScoreVisualizer.Components;
+using HitScoreVisualizer.Utilities.Extensions;
+using SiraUtil.Affinity;
+
+namespace HitScoreVisualizer.HarmonyPatches;
+
+internal class BadNoteCutEffectSpawnerPatch : IAffinity
+{
+	private readonly HsvFlyingEffectSpawner flyingEffectSpawner;
+
+	public BadNoteCutEffectSpawnerPatch(HsvFlyingEffectSpawner flyingEffectSpawner)
+	{
+		this.flyingEffectSpawner = flyingEffectSpawner;
+	}
+
+	[AffinityPrefix]
+	[AffinityPatch(typeof(BadNoteCutEffectSpawner), nameof(BadNoteCutEffectSpawner.HandleNoteWasCut))]
+	private bool HandleNoteWasCutPrefix(MissedNoteEffectSpawner __instance, NoteController noteController, in NoteCutInfo noteCutInfo)
+	{
+		if (noteController.noteData.time + 0.5f < __instance._audioTimeSyncController.songTime)
+		{
+			// Do nothing
+			return false;
+		}
+
+		if (noteController.IsBomb())
+		{
+			SpawnText("BOMB'D", in noteCutInfo);
+		}
+		else if (noteCutInfo.IsBadCut())
+		{
+			SpawnText(noteCutInfo.saberTypeOK ? "WRONG DIRECTION" : "WRONG COLOR", in noteCutInfo);
+		}
+
+		// Cancel the original implementation
+		return false;
+
+		void SpawnText(string text, in NoteCutInfo noteCutInfo)
+		{
+			flyingEffectSpawner.SpawnText(noteCutInfo.cutPoint, noteController.worldRotation, noteController.inverseWorldRotation, text);
+		}
+	}
+}

--- a/HitScoreVisualizer/HarmonyPatches/BadNoteCutEffectSpawnerPatch.cs
+++ b/HitScoreVisualizer/HarmonyPatches/BadNoteCutEffectSpawnerPatch.cs
@@ -1,22 +1,40 @@
+using System.Linq;
 using HitScoreVisualizer.Components;
+using HitScoreVisualizer.Models;
 using HitScoreVisualizer.Utilities.Extensions;
 using SiraUtil.Affinity;
+using UnityEngine;
+using Random = System.Random;
 
 namespace HitScoreVisualizer.HarmonyPatches;
 
 internal class BadNoteCutEffectSpawnerPatch : IAffinity
 {
 	private readonly HsvFlyingEffectSpawner flyingEffectSpawner;
+	private readonly PluginConfig pluginConfig;
+	private readonly Random random;
 
-	public BadNoteCutEffectSpawnerPatch(HsvFlyingEffectSpawner flyingEffectSpawner)
+	public BadNoteCutEffectSpawnerPatch(HsvFlyingEffectSpawner flyingEffectSpawner, PluginConfig pluginConfig, Random random)
 	{
 		this.flyingEffectSpawner = flyingEffectSpawner;
+		this.pluginConfig = pluginConfig;
+		this.random = random;
 	}
 
 	[AffinityPrefix]
 	[AffinityPatch(typeof(BadNoteCutEffectSpawner), nameof(BadNoteCutEffectSpawner.HandleNoteWasCut))]
 	private bool HandleNoteWasCutPrefix(MissedNoteEffectSpawner __instance, NoteController noteController, in NoteCutInfo noteCutInfo)
 	{
+		var badCutDisplays = pluginConfig.SelectedConfig?.Config?.BadCutDisplays;
+		if (badCutDisplays is null or [])
+		{
+			return true;
+		}
+
+		var bombs = badCutDisplays.Where(x => x.Type is BadCutDisplayType.Bomb or BadCutDisplayType.All).ToList();
+		var wrongDirections = badCutDisplays.Where(x => x.Type is BadCutDisplayType.WrongDirection or BadCutDisplayType.All).ToList();
+		var wrongColors = badCutDisplays.Where(x => x.Type is BadCutDisplayType.WrongColor or BadCutDisplayType.All).ToList();
+
 		if (noteController.noteData.time + 0.5f < __instance._audioTimeSyncController.songTime)
 		{
 			// Do nothing
@@ -25,19 +43,44 @@ internal class BadNoteCutEffectSpawnerPatch : IAffinity
 
 		if (noteController.IsBomb())
 		{
-			SpawnText("BOMB'D", in noteCutInfo);
+			if (bombs is [])
+			{
+				return true;
+			}
+
+			var display = bombs[random.Next(bombs.Count)];
+			SpawnText(display.Text, display.Color.ToColor(), in noteCutInfo);
 		}
 		else if (noteCutInfo.IsBadCut())
 		{
-			SpawnText(noteCutInfo.saberTypeOK ? "WRONG DIRECTION" : "WRONG COLOR", in noteCutInfo);
+			if (noteCutInfo.saberTypeOK)
+			{
+				if (wrongDirections is [])
+				{
+					return true;
+				}
+
+				var display = wrongDirections[random.Next(wrongDirections.Count)];
+				SpawnText(display.Text, display.Color.ToColor(), in noteCutInfo);
+			}
+			else
+			{
+				if (wrongColors is [])
+				{
+					return true;
+				}
+
+				var display = wrongColors[random.Next(wrongColors.Count)];
+				SpawnText(display.Text, display.Color.ToColor(), in noteCutInfo);
+			}
 		}
 
 		// Cancel the original implementation
 		return false;
 
-		void SpawnText(string text, in NoteCutInfo noteCutInfo)
+		void SpawnText(string text, Color? color, in NoteCutInfo noteCutInfo)
 		{
-			flyingEffectSpawner.SpawnText(noteCutInfo.cutPoint, noteController.worldRotation, noteController.inverseWorldRotation, text);
+			flyingEffectSpawner.SpawnText(noteCutInfo.cutPoint, noteController.worldRotation, noteController.inverseWorldRotation, text, color);
 		}
 	}
 }

--- a/HitScoreVisualizer/HarmonyPatches/BadNoteCutEffectSpawnerPatch.cs
+++ b/HitScoreVisualizer/HarmonyPatches/BadNoteCutEffectSpawnerPatch.cs
@@ -11,30 +11,31 @@ namespace HitScoreVisualizer.HarmonyPatches;
 internal class BadNoteCutEffectSpawnerPatch : IAffinity
 {
 	private readonly HsvFlyingEffectSpawner flyingEffectSpawner;
-	private readonly PluginConfig pluginConfig;
 	private readonly Random random;
 
-	public BadNoteCutEffectSpawnerPatch(HsvFlyingEffectSpawner flyingEffectSpawner, PluginConfig pluginConfig, Random random)
+	private readonly BadCutDisplay[] wrongDirectionDisplays = [];
+	private readonly BadCutDisplay[] wrongColorDisplays = [];
+	private readonly BadCutDisplay[] bombDisplays = [];
+
+	public BadNoteCutEffectSpawnerPatch(HsvFlyingEffectSpawner flyingEffectSpawner, HsvConfigModel config, Random random)
 	{
 		this.flyingEffectSpawner = flyingEffectSpawner;
-		this.pluginConfig = pluginConfig;
 		this.random = random;
+
+		if (config.BadCutDisplays is null or [])
+		{
+			return;
+		}
+
+		wrongDirectionDisplays = config.BadCutDisplays.Where(x => x.Type is BadCutDisplayType.WrongDirection or BadCutDisplayType.All).ToArray();
+		wrongColorDisplays = config.BadCutDisplays.Where(x => x.Type is BadCutDisplayType.WrongColor or BadCutDisplayType.All).ToArray();
+		bombDisplays = config.BadCutDisplays.Where(x => x.Type is BadCutDisplayType.Bomb or BadCutDisplayType.All).ToArray();
 	}
 
 	[AffinityPrefix]
 	[AffinityPatch(typeof(BadNoteCutEffectSpawner), nameof(BadNoteCutEffectSpawner.HandleNoteWasCut))]
 	private bool HandleNoteWasCutPrefix(MissedNoteEffectSpawner __instance, NoteController noteController, in NoteCutInfo noteCutInfo)
 	{
-		var badCutDisplays = pluginConfig.SelectedConfig?.Config?.BadCutDisplays;
-		if (badCutDisplays is null or [])
-		{
-			return true;
-		}
-
-		var bombs = badCutDisplays.Where(x => x.Type is BadCutDisplayType.Bomb or BadCutDisplayType.All).ToList();
-		var wrongDirections = badCutDisplays.Where(x => x.Type is BadCutDisplayType.WrongDirection or BadCutDisplayType.All).ToList();
-		var wrongColors = badCutDisplays.Where(x => x.Type is BadCutDisplayType.WrongColor or BadCutDisplayType.All).ToList();
-
 		if (noteController.noteData.time + 0.5f < __instance._audioTimeSyncController.songTime)
 		{
 			// Do nothing
@@ -43,44 +44,42 @@ internal class BadNoteCutEffectSpawnerPatch : IAffinity
 
 		if (noteController.IsBomb())
 		{
-			if (bombs is [])
-			{
-				return true;
-			}
-
-			var display = bombs[random.Next(bombs.Count)];
-			SpawnText(display.Text, display.Color.ToColor(), in noteCutInfo);
+			return !TrySpawnRandomText(bombDisplays, in noteCutInfo, noteController);
 		}
-		else if (noteCutInfo.IsBadCut())
+
+		if (!noteCutInfo.IsBadCut())
 		{
-			if (noteCutInfo.saberTypeOK)
-			{
-				if (wrongDirections is [])
-				{
-					return true;
-				}
-
-				var display = wrongDirections[random.Next(wrongDirections.Count)];
-				SpawnText(display.Text, display.Color.ToColor(), in noteCutInfo);
-			}
-			else
-			{
-				if (wrongColors is [])
-				{
-					return true;
-				}
-
-				var display = wrongColors[random.Next(wrongColors.Count)];
-				SpawnText(display.Text, display.Color.ToColor(), in noteCutInfo);
-			}
+			// Not a bomb or a bad cut, do nothing
+			return false;
 		}
+
+		if (!noteCutInfo.saberTypeOK)
+		{
+			return !TrySpawnRandomText(wrongColorDisplays, in noteCutInfo, noteController);
+		}
+
+		return !TrySpawnRandomText(wrongDirectionDisplays, in noteCutInfo, noteController);
 
 		// Cancel the original implementation
-		return false;
+	}
 
-		void SpawnText(string text, Color? color, in NoteCutInfo noteCutInfo)
+
+	private bool TrySpawnRandomText(BadCutDisplay[] displays, in NoteCutInfo noteCutInfo, NoteController noteController)
+	{
+		if (displays is [])
 		{
-			flyingEffectSpawner.SpawnText(noteCutInfo.cutPoint, noteController.worldRotation, noteController.inverseWorldRotation, text, color);
+			return false;
 		}
+
+		var display = displays[random.Next(0, displays.Length)];
+
+		flyingEffectSpawner.SpawnText(
+			noteCutInfo.cutPoint,
+			noteController.worldRotation,
+			noteController.inverseWorldRotation,
+			display.Text,
+			display.Color.ToColor());
+
+		return true;
 	}
 }

--- a/HitScoreVisualizer/HarmonyPatches/GameCoreInstallerHook.cs
+++ b/HitScoreVisualizer/HarmonyPatches/GameCoreInstallerHook.cs
@@ -1,0 +1,30 @@
+using HitScoreVisualizer.Components;
+using HitScoreVisualizer.Models;
+using SiraUtil.Affinity;
+using UnityEngine;
+
+namespace HitScoreVisualizer.HarmonyPatches;
+
+public class GameCoreInstallerHook : IAffinity
+{
+	[AffinityPrefix]
+	[AffinityPatch(typeof(GameplayCoreInstaller), nameof(GameplayCoreInstaller.InstallBindings))]
+	private void InstallBindingsPostfix(GameplayCoreInstaller __instance)
+	{
+		var container = __instance.Container;
+		var missSpriteSpawner = __instance._missedNoteEffectSpawnerPrefab._missedNoteFlyingSpriteSpawner;
+		var flyingTextEffect = __instance._effectPoolsManualInstaller._flyingTextEffectPrefab;
+
+		container.BindInstance(new HsvFlyingEffectSpawner.InitData(
+			missSpriteSpawner._duration,
+			missSpriteSpawner._xSpread,
+			missSpriteSpawner._targetYPos,
+			missSpriteSpawner._targetZPos,
+			Color.white,
+			4.5f)).AsSingle();
+
+		container.BindInstance(new FlyingTextEffectAnimationData(
+			flyingTextEffect._fadeAnimationCurve,
+			flyingTextEffect._moveAnimationCurve)).AsSingle();
+	}
+}

--- a/HitScoreVisualizer/HarmonyPatches/HarmonyPatchManager.cs
+++ b/HitScoreVisualizer/HarmonyPatches/HarmonyPatchManager.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Reflection;
 using HarmonyLib;
-using SiraUtil.Logging;
 using Zenject;
 
 namespace HitScoreVisualizer.HarmonyPatches;

--- a/HitScoreVisualizer/HarmonyPatches/MissedNoteEffectSpawnerPatch.cs
+++ b/HitScoreVisualizer/HarmonyPatches/MissedNoteEffectSpawnerPatch.cs
@@ -31,7 +31,8 @@ internal class MissedNoteEffectSpawnerPatch : IAffinity
 			noteController.worldRotation * position,
 			noteController.worldRotation,
 			noteController.inverseWorldRotation,
-			"MISSED");
+			"MISSED",
+			null);
 
 		// Cancel the original implementation
 		return false;

--- a/HitScoreVisualizer/HarmonyPatches/MissedNoteEffectSpawnerPatch.cs
+++ b/HitScoreVisualizer/HarmonyPatches/MissedNoteEffectSpawnerPatch.cs
@@ -1,0 +1,39 @@
+using HitScoreVisualizer.Components;
+using SiraUtil.Affinity;
+
+namespace HitScoreVisualizer.HarmonyPatches;
+
+internal class MissedNoteEffectSpawnerPatch : IAffinity
+{
+	private readonly HsvFlyingEffectSpawner flyingEffectSpawner;
+
+	public MissedNoteEffectSpawnerPatch(HsvFlyingEffectSpawner flyingEffectSpawner)
+	{
+		this.flyingEffectSpawner = flyingEffectSpawner;
+	}
+
+	[AffinityPrefix]
+	[AffinityPatch(typeof(MissedNoteEffectSpawner), nameof(MissedNoteEffectSpawner.HandleNoteWasMissed))]
+	private bool HandleNoteWasMissedPrefix(MissedNoteEffectSpawner __instance, NoteController noteController)
+	{
+		if (noteController.hidden
+		    || noteController.noteData.time + 0.5f < __instance._audioTimeSyncController.songTime
+		    || noteController.noteData.colorType == ColorType.None)
+		{
+			// Do nothing
+			return false;
+		}
+
+		var position = noteController.inverseWorldRotation * noteController.noteTransform.position;
+		position.z = __instance._spawnPosZ;
+
+		flyingEffectSpawner.SpawnText(
+			noteController.worldRotation * position,
+			noteController.worldRotation,
+			noteController.inverseWorldRotation,
+			"MISSED");
+
+		// Cancel the original implementation
+		return false;
+	}
+}

--- a/HitScoreVisualizer/HitScoreVisualizer.csproj
+++ b/HitScoreVisualizer/HitScoreVisualizer.csproj
@@ -43,6 +43,10 @@
 			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.ViewSystem.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
+		<Reference Include="BGLib.DotnetExtension">
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.DotnetExtension.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
 		<Reference Include="BGLib.UnityExtension">
 			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.UnityExtension.dll</HintPath>
 			<Private>false</Private>
@@ -117,6 +121,10 @@
 		</Reference>
 		<Reference Include="UnityEngine.TextRenderingModule">
 			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="UnityEngine.UI">
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="Zenject" Publicize="true">

--- a/HitScoreVisualizer/Installers/HsvAppInstaller.cs
+++ b/HitScoreVisualizer/Installers/HsvAppInstaller.cs
@@ -25,8 +25,6 @@ internal sealed class HsvAppInstaller : Installer
 
 		Container.BindInterfacesAndSelfTo<BloomFontProvider>().AsSingle();
 
-		Container.Bind<JudgmentService>().AsSingle();
-
 		// Patches
 		Container.BindInterfacesTo<HarmonyPatchManager>().AsSingle();
 		Container.BindInterfacesTo<EffectPoolsManualInstallerPatch>().AsSingle();

--- a/HitScoreVisualizer/Installers/HsvAppInstaller.cs
+++ b/HitScoreVisualizer/Installers/HsvAppInstaller.cs
@@ -30,6 +30,6 @@ internal sealed class HsvAppInstaller : Installer
 		// Patches
 		Container.BindInterfacesTo<HarmonyPatchManager>().AsSingle();
 		Container.BindInterfacesTo<EffectPoolsManualInstallerPatch>().AsSingle();
-		Container.BindInterfacesTo<FlyingScoreEffectPatch>().AsSingle();
+		Container.BindInterfacesTo<GameCoreInstallerHook>().AsSingle();
 	}
 }

--- a/HitScoreVisualizer/Installers/HsvPlayerInstaller.cs
+++ b/HitScoreVisualizer/Installers/HsvPlayerInstaller.cs
@@ -1,7 +1,5 @@
 using HitScoreVisualizer.Components;
 using HitScoreVisualizer.HarmonyPatches;
-using TMPro;
-using UnityEngine;
 using Zenject;
 
 namespace HitScoreVisualizer.Installers;

--- a/HitScoreVisualizer/Installers/HsvPlayerInstaller.cs
+++ b/HitScoreVisualizer/Installers/HsvPlayerInstaller.cs
@@ -1,5 +1,6 @@
 using HitScoreVisualizer.Components;
 using HitScoreVisualizer.HarmonyPatches;
+using HitScoreVisualizer.Utilities.Services;
 using Zenject;
 
 namespace HitScoreVisualizer.Installers;
@@ -25,8 +26,9 @@ internal class HsvPlayerInstaller : Installer
 
 		Container.BindInstance(currentConfig).AsSingle();
 
-		Container.Bind<HsvFlyingEffectSpawner>().FromNewComponentOnNewGameObject().AsSingle();
+		Container.Bind<JudgmentService>().AsSingle();
 
+		Container.Bind<HsvFlyingEffectSpawner>().FromNewComponentOnNewGameObject().AsSingle();
 		Container.BindMemoryPool<HsvFlyingEffect, HsvFlyingEffect.Pool>()
 			.WithInitialSize(20)
 			.FromComponentInNewPrefab(hsvFlyingEffectPrefab);

--- a/HitScoreVisualizer/Installers/HsvPlayerInstaller.cs
+++ b/HitScoreVisualizer/Installers/HsvPlayerInstaller.cs
@@ -6,10 +6,25 @@ namespace HitScoreVisualizer.Installers;
 
 internal class HsvPlayerInstaller : Installer
 {
+	private readonly PluginConfig pluginConfig;
 	private readonly HsvFlyingEffect hsvFlyingEffectPrefab = HsvFlyingEffect.CreatePrefab();
+
+	public HsvPlayerInstaller(PluginConfig pluginConfig)
+	{
+		this.pluginConfig = pluginConfig;
+	}
 
 	public override void InstallBindings()
 	{
+		var currentConfig = pluginConfig.SelectedConfig?.Config;
+		if (currentConfig is null)
+		{
+			// No valid HSV config is selected, so HSV will not do anything during gameplay
+			return;
+		}
+
+		Container.BindInstance(currentConfig).AsSingle();
+
 		Container.Bind<HsvFlyingEffectSpawner>().FromNewComponentOnNewGameObject().AsSingle();
 
 		Container.BindMemoryPool<HsvFlyingEffect, HsvFlyingEffect.Pool>()

--- a/HitScoreVisualizer/Installers/HsvPlayerInstaller.cs
+++ b/HitScoreVisualizer/Installers/HsvPlayerInstaller.cs
@@ -1,0 +1,26 @@
+using HitScoreVisualizer.Components;
+using HitScoreVisualizer.HarmonyPatches;
+using TMPro;
+using UnityEngine;
+using Zenject;
+
+namespace HitScoreVisualizer.Installers;
+
+internal class HsvPlayerInstaller : Installer
+{
+	private readonly HsvFlyingEffect hsvFlyingEffectPrefab = HsvFlyingEffect.CreatePrefab();
+
+	public override void InstallBindings()
+	{
+		Container.Bind<HsvFlyingEffectSpawner>().FromNewComponentOnNewGameObject().AsSingle();
+
+		Container.BindMemoryPool<HsvFlyingEffect, HsvFlyingEffect.Pool>()
+			.WithInitialSize(20)
+			.FromComponentInNewPrefab(hsvFlyingEffectPrefab);
+
+		// Patches
+		Container.BindInterfacesTo<MissedNoteEffectSpawnerPatch>().AsSingle();
+		Container.BindInterfacesTo<BadNoteCutEffectSpawnerPatch>().AsSingle();
+		Container.BindInterfacesTo<FlyingScoreEffectPatch>().AsSingle();
+	}
+}

--- a/HitScoreVisualizer/Models/BadCutDisplay.cs
+++ b/HitScoreVisualizer/Models/BadCutDisplay.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace HitScoreVisualizer.Models;
+
+[Serializable]
+public class BadCutDisplay
+{
+	public required string Text { get; init; }
+
+	public required List<float> Color { get; init; }
+
+	public BadCutDisplayType? Type { get; init; } = BadCutDisplayType.All;
+}

--- a/HitScoreVisualizer/Models/BadCutDisplayType.cs
+++ b/HitScoreVisualizer/Models/BadCutDisplayType.cs
@@ -1,0 +1,24 @@
+namespace HitScoreVisualizer.Models;
+
+public enum BadCutDisplayType
+{
+	/// <summary>
+	/// This display will be used for any kind of bad cut
+	/// </summary>
+	All,
+
+	/// <summary>
+	/// This display will be used when the bad cut is caused by the note being cut in the wrong direction by the correct color saber
+	/// </summary>
+	WrongDirection,
+
+	/// <summary>
+	/// This display will be used when the bad cut is caused by the note being cut by the wrong color saber
+	/// </summary>
+	WrongColor,
+
+	/// <summary>
+	/// This display will be used by bad cuts caused by hitting bombs
+	/// </summary>
+	Bomb
+}

--- a/HitScoreVisualizer/Models/ChainHeadJudgment.cs
+++ b/HitScoreVisualizer/Models/ChainHeadJudgment.cs
@@ -5,25 +5,25 @@ using Newtonsoft.Json;
 namespace HitScoreVisualizer.Models;
 
 [Serializable]
-public class ChainHeadJudgment
+public class ChainHeadJudgment : IJudgment
 {
 	// This judgment will be applied only to chain note heads hit with score >= this number.
 	// Note that if no judgment can be applied to a note, the text will appear as in the unmodded
 	// game.
-	public required int Threshold { get; set; }
+	public required int Threshold { get; init; }
 
 	// The text to display (if judgment text is enabled).
-	public required string Text { get; set; }
+	public required string Text { get; init; }
 
 	// 4 floats, 0-1; red, green, blue, glow (not transparency!)
 	// leaving this out should look obviously wrong
-	public required List<float> Color { get; set; }
+	public required List<float> Color { get; init; }
 
 	// If true, the text color will be interpolated between this judgment's color and the previous
 	// based on how close to the next threshold it is.
 	// Specifying fade : true for the first judgment in the array is an error, and will crash the
 	// plugin.
-	public bool Fade { get; set; }
+	public bool Fade { get; init; }
 
 	[JsonIgnore]
 	internal static ChainHeadJudgment Default { get; } = new()

--- a/HitScoreVisualizer/Models/ConfigMigrations/ConfigMigration200.cs
+++ b/HitScoreVisualizer/Models/ConfigMigrations/ConfigMigration200.cs
@@ -1,7 +1,6 @@
-using HitScoreVisualizer.Models;
 using Hive.Versioning;
 
-namespace HitScoreVisualizer.Utilities.Services;
+namespace HitScoreVisualizer.Models.ConfigMigrations;
 
 internal class ConfigMigration200 : IHsvConfigMigration
 {

--- a/HitScoreVisualizer/Models/ConfigMigrations/ConfigMigration210.cs
+++ b/HitScoreVisualizer/Models/ConfigMigrations/ConfigMigration210.cs
@@ -1,8 +1,7 @@
 using System.Linq;
-using HitScoreVisualizer.Models;
 using Hive.Versioning;
 
-namespace HitScoreVisualizer.Utilities.Services;
+namespace HitScoreVisualizer.Models.ConfigMigrations;
 
 internal class ConfigMigration210 : IHsvConfigMigration
 {

--- a/HitScoreVisualizer/Models/ConfigMigrations/ConfigMigration223.cs
+++ b/HitScoreVisualizer/Models/ConfigMigrations/ConfigMigration223.cs
@@ -1,7 +1,6 @@
-using HitScoreVisualizer.Models;
 using Hive.Versioning;
 
-namespace HitScoreVisualizer.Utilities.Services;
+namespace HitScoreVisualizer.Models.ConfigMigrations;
 
 internal class ConfigMigration223 : IHsvConfigMigration
 {

--- a/HitScoreVisualizer/Models/ConfigMigrations/ConfigMigration320.cs
+++ b/HitScoreVisualizer/Models/ConfigMigrations/ConfigMigration320.cs
@@ -1,8 +1,7 @@
-using HitScoreVisualizer.Models;
 using Hive.Versioning;
 using UnityEngine;
 
-namespace HitScoreVisualizer.Utilities.Services;
+namespace HitScoreVisualizer.Models.ConfigMigrations;
 
 internal class ConfigMigration320 : IHsvConfigMigration
 {

--- a/HitScoreVisualizer/Models/ConfigMigrations/IHsvConfigMigration.cs
+++ b/HitScoreVisualizer/Models/ConfigMigrations/IHsvConfigMigration.cs
@@ -1,7 +1,6 @@
-using HitScoreVisualizer.Models;
 using Hive.Versioning;
 
-namespace HitScoreVisualizer.Utilities.Services;
+namespace HitScoreVisualizer.Models.ConfigMigrations;
 
 internal interface IHsvConfigMigration
 {

--- a/HitScoreVisualizer/Models/ConfigValidations/BadCutDisplaysValidation.cs
+++ b/HitScoreVisualizer/Models/ConfigValidations/BadCutDisplaysValidation.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+
+namespace HitScoreVisualizer.Models.ConfigValidations;
+
+internal class BadCutDisplaysValidation : IConfigValidation
+{
+	public bool IsValid(HsvConfigModel config)
+	{
+		var displays = config.BadCutDisplays;
+		if (displays is null)
+		{
+			return true;
+		}
+
+		var colors = displays.Select(x => x.Color).ToList();
+		if (colors.Any(color => color.Count != 4))
+		{
+			Plugin.Log.Warn("Bad cut display color is invalid; make sure to include exactly 4 numbers");
+			return false;
+		}
+
+		if (colors.Any(color => !color.All(x => x >= 0f)))
+		{
+			Plugin.Log.Warn("Bad cut display color is invalid; all numbers must be positive and preferably less than or equal to 1");
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/HitScoreVisualizer/Models/ConfigValidations/ChainLinkDisplayValidation.cs
+++ b/HitScoreVisualizer/Models/ConfigValidations/ChainLinkDisplayValidation.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+
+namespace HitScoreVisualizer.Models.ConfigValidations;
+
+internal class ChainLinkDisplayValidation : IConfigValidation
+{
+	public bool IsValid(HsvConfigModel config)
+	{
+		var display = config.ChainLinkDisplay;
+		if (display is null)
+		{
+			return true;
+		}
+
+		var color = display.Color;
+		if (color.Count != 4)
+		{
+			Plugin.Log.Warn("Chain link display color is invalid; make sure to include exactly 4 numbers");
+			return false;
+		}
+
+		if (!color.All(x => x >= 0f))
+		{
+			Plugin.Log.Warn("Chain link display color is invalid; all numbers must be positive and preferably less than or equal to 1");
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/HitScoreVisualizer/Models/ConfigValidations/IConfigValidation.cs
+++ b/HitScoreVisualizer/Models/ConfigValidations/IConfigValidation.cs
@@ -1,0 +1,6 @@
+namespace HitScoreVisualizer.Models.ConfigValidations;
+
+internal interface IConfigValidation
+{
+	bool IsValid(HsvConfigModel config);
+}

--- a/HitScoreVisualizer/Models/ConfigValidations/JudgmentSegmentsValidation.cs
+++ b/HitScoreVisualizer/Models/ConfigValidations/JudgmentSegmentsValidation.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HitScoreVisualizer.Models.ConfigValidations;
+
+internal class JudgmentSegmentsValidation : IConfigValidation
+{
+	private readonly Func<HsvConfigModel, List<JudgmentSegment>?> propertyGetter;
+
+	public JudgmentSegmentsValidation(Func<HsvConfigModel, List<JudgmentSegment>?> propertyGetter)
+	{
+		this.propertyGetter = propertyGetter;
+	}
+
+	public bool IsValid(HsvConfigModel config)
+	{
+		var segments = propertyGetter(config);
+		if (segments is null || segments.Count <= 1)
+		{
+			return true;
+		}
+
+		var isOrdered = segments
+			.Zip(segments.Skip(1), (a, b) => a.Threshold > b.Threshold)
+			.All(x => x);
+
+		var hasDuplicate = segments
+			.OrderBy(j => j.Threshold)
+			.Zip(segments.Skip(1), (a, b) => a.Threshold != b.Threshold)
+			.All(x => x);
+
+		if (!isOrdered)
+		{
+			Plugin.Log.Warn("Judgment segments are not correctly ordered; they should be ordered from highest to lowest threshold");
+		}
+
+		if (hasDuplicate)
+		{
+			Plugin.Log.Warn("Judgment segments contain a duplicate threshold");
+		}
+
+		return isOrdered && !hasDuplicate;
+	}
+}

--- a/HitScoreVisualizer/Models/ConfigValidations/JudgmentsValidation.cs
+++ b/HitScoreVisualizer/Models/ConfigValidations/JudgmentsValidation.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HitScoreVisualizer.Models.ConfigValidations;
+
+internal class JudgmentsValidation : IConfigValidation
+{
+	private readonly Func<HsvConfigModel, IEnumerable<IJudgment>> propertyGetter;
+
+	public JudgmentsValidation(Func<HsvConfigModel, IEnumerable<IJudgment>> propertyGetter)
+	{
+		this.propertyGetter = propertyGetter;
+	}
+
+	public bool IsValid(HsvConfigModel config)
+	{
+		var judgments = propertyGetter(config).ToList();
+		if (judgments is [])
+		{
+			Plugin.Log.Warn("Config contains no Judgments when it should specify at least one Judgment");
+			return false;
+		}
+
+		var isOrdered = judgments
+			.Zip(judgments.Skip(1), (a, b) => a.Threshold > b.Threshold)
+			.All(x => x);
+
+		if (!isOrdered)
+		{
+			Plugin.Log.Warn("Judgments are not correctly ordered; they should be ordered from highest to lowest threshold");
+			return false;
+		}
+
+		var isHighestJudgmentValid = judgments.First().Fade;
+
+		var hasDuplicates = judgments
+			.OrderBy(x => x.Threshold)
+			.Zip(judgments.Skip(1), (a, b) => a.Threshold != b.Threshold)
+			.All(x => x);
+
+		var areColorsValid = judgments.All(IsJudgmentColorValid);
+
+		if (!isHighestJudgmentValid)
+		{
+			Plugin.Log.Warn("The first judgment cannot have fade set to true");
+		}
+
+		if (hasDuplicates)
+		{
+			Plugin.Log.Warn("Judgments contain a duplicate threshold");
+		}
+
+		if (!areColorsValid)
+		{
+			Plugin.Log.Warn("One or more Judgments contain an invalid color");
+		}
+
+		return isHighestJudgmentValid && !hasDuplicates && areColorsValid;
+	}
+
+	private static bool IsJudgmentColorValid(IJudgment judgment)
+	{
+		if (judgment.Color.Count != 4)
+		{
+			Plugin.Log.Warn($"Judgment for threshold {judgment.Threshold} has invalid color. Make sure to include exactly 4 numbers for each judgment's color!");
+			return false;
+		}
+
+		if (judgment.Color.All(x => x >= 0f))
+		{
+			return true;
+		}
+
+		Plugin.Log.Warn($"Judgment for threshold {judgment.Threshold} has invalid color. Make sure to include exactly 4 numbers that are greater or equal than 0 (and preferably smaller or equal than 1) for each judgment's color!");
+		return false;
+	}
+}

--- a/HitScoreVisualizer/Models/ConfigValidations/JudgmentsValidation.cs
+++ b/HitScoreVisualizer/Models/ConfigValidations/JudgmentsValidation.cs
@@ -32,9 +32,9 @@ internal class JudgmentsValidation : IConfigValidation
 			return false;
 		}
 
-		var isHighestJudgmentValid = judgments.First().Fade;
+		var isHighestJudgmentValid = !judgments.First().Fade;
 
-		var hasDuplicates = judgments
+		var hasDuplicates = judgments.Count > 1 && judgments
 			.OrderBy(x => x.Threshold)
 			.Zip(judgments.Skip(1), (a, b) => a.Threshold != b.Threshold)
 			.All(x => x);

--- a/HitScoreVisualizer/Models/ConfigValidations/MissDisplaysValidation.cs
+++ b/HitScoreVisualizer/Models/ConfigValidations/MissDisplaysValidation.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+
+namespace HitScoreVisualizer.Models.ConfigValidations;
+
+internal class MissDisplaysValidation : IConfigValidation
+{
+	public bool IsValid(HsvConfigModel config)
+	{
+		var displays = config.MissDisplays;
+		if (displays is null)
+		{
+			return true;
+		}
+
+		var colors = displays.Select(x => x.Color).ToList();
+		if (colors.Any(color => color.Count != 4))
+		{
+			Plugin.Log.Warn("Miss display color is invalid; make sure to include exactly 4 numbers");
+			return false;
+		}
+
+		if (colors.Any(color => !color.All(x => x >= 0f)))
+		{
+			Plugin.Log.Warn("Miss display color is invalid; all numbers must be positive and preferably less than or equal to 1");
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/HitScoreVisualizer/Models/ConfigValidations/TimeDependenceDecimalValidation.cs
+++ b/HitScoreVisualizer/Models/ConfigValidations/TimeDependenceDecimalValidation.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace HitScoreVisualizer.Models.ConfigValidations;
+
+internal class TimeDependenceDecimalValidation : IConfigValidation
+{
+	public bool IsValid(HsvConfigModel config)
+	{
+		// 99 is the max for NumberFormatInfo.NumberDecimalDigits
+		if (config.TimeDependenceDecimalPrecision is < 0 or > 99)
+		{
+			Plugin.Log.Warn("timeDependencyDecimalPrecision is outside the range 0 to 99");
+			return false;
+		}
+
+		if (config.TimeDependenceDecimalOffset < 0 || config.TimeDependenceDecimalOffset > Math.Log10(float.MaxValue))
+		{
+			Plugin.Log.Warn($"timeDependencyDecimalOffset value is outside the range 0 to {(int) Math.Log10(float.MaxValue)}");
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/HitScoreVisualizer/Models/ConfigValidations/TimeDependenceJudgmentsValidation.cs
+++ b/HitScoreVisualizer/Models/ConfigValidations/TimeDependenceJudgmentsValidation.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using UnityEngine;
+
+namespace HitScoreVisualizer.Models.ConfigValidations;
+
+internal class TimeDependenceJudgmentsValidation : IConfigValidation
+{
+	public bool IsValid(HsvConfigModel config)
+	{
+		var judgments = config.TimeDependenceJudgments;
+		if (judgments is null || judgments.Count <= 1)
+		{
+			return true;
+		}
+
+		var isOrdered = judgments
+			.Zip(judgments.Skip(1), (a, b) => a.Threshold > b.Threshold)
+			.All(x => x);
+
+		var hasDuplicate = judgments
+			.OrderBy(j => j.Threshold)
+			.Zip(judgments.Skip(1), (a, b) => !Mathf.Approximately(a.Threshold, b.Threshold))
+			.All(x => x);
+
+		if (!isOrdered)
+		{
+			Plugin.Log.Warn("Time dependence judgments are not correctly ordered; they should be ordered from highest to lowest threshold");
+		}
+
+		if (hasDuplicate)
+		{
+			Plugin.Log.Warn("Time dependence judgments contain a duplicate threshold");
+		}
+
+		return isOrdered && !hasDuplicate;
+	}
+}

--- a/HitScoreVisualizer/Models/FlyingTextEffectAnimationData.cs
+++ b/HitScoreVisualizer/Models/FlyingTextEffectAnimationData.cs
@@ -1,0 +1,5 @@
+using UnityEngine;
+
+namespace HitScoreVisualizer.Models;
+
+internal record FlyingTextEffectAnimationData(AnimationCurve Fade, AnimationCurve Move);

--- a/HitScoreVisualizer/Models/HsvConfigModel.cs
+++ b/HitScoreVisualizer/Models/HsvConfigModel.cs
@@ -44,6 +44,8 @@ public class HsvConfigModel
 	public int TimeDependenceDecimalOffset { get; set; } = 2;
 	public List<TimeDependenceJudgmentSegment>? TimeDependenceJudgments { get; set; }
 
+	public List<BadCutDisplay>? BadCutDisplays { get; set; }
+
 	[JsonIgnore]
 	internal static HsvConfigModel Default { get; } = new()
 	{

--- a/HitScoreVisualizer/Models/HsvConfigModel.cs
+++ b/HitScoreVisualizer/Models/HsvConfigModel.cs
@@ -44,8 +44,10 @@ public class HsvConfigModel
 	public int TimeDependenceDecimalOffset { get; set; } = 2;
 	public List<TimeDependenceJudgmentSegment>? TimeDependenceJudgments { get; set; }
 
+	public bool RandomizeBadCutDisplays { get; set; } = true;
 	public List<BadCutDisplay>? BadCutDisplays { get; set; }
 
+	public bool RandomizeMissDisplays { get; set; } = true;
 	public List<MissDisplay>? MissDisplays { get; set; }
 
 	[JsonIgnore]

--- a/HitScoreVisualizer/Models/HsvConfigModel.cs
+++ b/HitScoreVisualizer/Models/HsvConfigModel.cs
@@ -46,6 +46,8 @@ public class HsvConfigModel
 
 	public List<BadCutDisplay>? BadCutDisplays { get; set; }
 
+	public List<MissDisplay>? MissDisplays { get; set; }
+
 	[JsonIgnore]
 	internal static HsvConfigModel Default { get; } = new()
 	{

--- a/HitScoreVisualizer/Models/IJudgment.cs
+++ b/HitScoreVisualizer/Models/IJudgment.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace HitScoreVisualizer.Models;
+
+internal interface IJudgment
+{
+	int Threshold { get; init; }
+	string Text { get; init; }
+	List<float> Color { get; init; }
+	bool Fade { get; init; }
+}

--- a/HitScoreVisualizer/Models/MissDisplay.cs
+++ b/HitScoreVisualizer/Models/MissDisplay.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace HitScoreVisualizer.Models;
+
+public class MissDisplay
+{
+	public required string Text { get; init; }
+
+	public required List<float> Color { get; init; }
+}

--- a/HitScoreVisualizer/Models/NormalJudgment.cs
+++ b/HitScoreVisualizer/Models/NormalJudgment.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace HitScoreVisualizer.Models;
 
-public class NormalJudgment
+public class NormalJudgment : IJudgment
 {
 	// This judgment will be applied only to normal notes hit with score >= this number.
 	// Note that if no judgment can be applied to a note, the text will appear as in the unmodded

--- a/HitScoreVisualizer/Plugin.cs
+++ b/HitScoreVisualizer/Plugin.cs
@@ -31,5 +31,6 @@ public class Plugin
 
 		zenject.Install<HsvAppInstaller>(Location.App, Config);
 		zenject.Install<HsvMenuInstaller>(Location.Menu);
+		zenject.Install<HsvPlayerInstaller>(Location.Player);
 	}
 }

--- a/HitScoreVisualizer/Plugin.cs
+++ b/HitScoreVisualizer/Plugin.cs
@@ -1,13 +1,9 @@
-using System;
 using HitScoreVisualizer.Installers;
-using HitScoreVisualizer.Utilities.Json;
 using IPA;
 using IPA.Config;
 using IPA.Config.Stores;
 using IPA.Loader;
-using Newtonsoft.Json;
 using SiraUtil.Zenject;
-using UnityEngine;
 using Logger = IPA.Logging.Logger;
 
 namespace HitScoreVisualizer;

--- a/HitScoreVisualizer/UI/PluginSettingsViewController.cs
+++ b/HitScoreVisualizer/UI/PluginSettingsViewController.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using BeatSaberMarkupLanguage.Attributes;
 using BeatSaberMarkupLanguage.ViewControllers;
 using HitScoreVisualizer.Models;
-using HitScoreVisualizer.Utilities.Services;
 using Zenject;
 
 namespace HitScoreVisualizer.UI;

--- a/HitScoreVisualizer/Utilities/Extensions/DirectionConversion.cs
+++ b/HitScoreVisualizer/Utilities/Extensions/DirectionConversion.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using HitScoreVisualizer.Models;
-using IPA.Utilities;
 using UnityEngine;
 
 namespace HitScoreVisualizer.Utilities.Extensions;

--- a/HitScoreVisualizer/Utilities/Extensions/HsvConfigValidation.cs
+++ b/HitScoreVisualizer/Utilities/Extensions/HsvConfigValidation.cs
@@ -1,179 +1,25 @@
-using System;
-using System.Collections.Generic;
+
 using System.Linq;
 using HitScoreVisualizer.Models;
+using HitScoreVisualizer.Models.ConfigValidations;
 
 namespace HitScoreVisualizer.Utilities.Extensions;
 
 internal static class HsvConfigValidation
 {
+	private static IConfigValidation[] Validations { get; } =
+	[
+		new TimeDependenceDecimalValidation(),
+		new JudgmentsValidation(config => config.Judgments),
+		new JudgmentsValidation(config => config.ChainHeadJudgments),
+		new JudgmentSegmentsValidation(config => config.BeforeCutAngleJudgments),
+		new JudgmentSegmentsValidation(config => config.AccuracyJudgments),
+		new JudgmentSegmentsValidation(config => config.AfterCutAngleJudgments),
+		new TimeDependenceJudgmentsValidation()
+	];
+
 	public static bool Validate(this HsvConfigModel configuration)
 	{
-		if (!configuration.Judgments.Any() || !ValidateJudgments(configuration))
-		{
-			return false;
-		}
-
-		// 99 is the max for NumberFormatInfo.NumberDecimalDigits
-		if (configuration.TimeDependenceDecimalPrecision is < 0 or > 99)
-		{
-			Plugin.Log.Warn($"timeDependencyDecimalPrecision value {configuration.TimeDependenceDecimalPrecision} is outside the range of acceptable values [0, 99]");
-			return false;
-		}
-
-		if (configuration.TimeDependenceDecimalOffset < 0 || configuration.TimeDependenceDecimalOffset > Math.Log10(float.MaxValue))
-		{
-			Plugin.Log.Warn($"timeDependencyDecimalOffset value {configuration.TimeDependenceDecimalOffset} is outside the range of acceptable values [0, {(int) Math.Log10(float.MaxValue)}]");
-			return false;
-		}
-
-		if (configuration.BeforeCutAngleJudgments != null)
-		{
-			configuration.BeforeCutAngleJudgments = configuration.BeforeCutAngleJudgments.OrderByDescending(x => x.Threshold).ToList();
-			if (!ValidateJudgmentSegment(configuration.BeforeCutAngleJudgments))
-			{
-				return false;
-			}
-		}
-
-		if (configuration.AccuracyJudgments != null)
-		{
-			configuration.AccuracyJudgments = configuration.AccuracyJudgments.OrderByDescending(x => x.Threshold).ToList();
-			if (!ValidateJudgmentSegment(configuration.AccuracyJudgments))
-			{
-				return false;
-			}
-		}
-
-		if (configuration.AfterCutAngleJudgments != null)
-		{
-			configuration.AfterCutAngleJudgments = configuration.AfterCutAngleJudgments.OrderByDescending(x => x.Threshold).ToList();
-			if (!ValidateJudgmentSegment(configuration.AfterCutAngleJudgments))
-			{
-				return false;
-			}
-		}
-
-		if (configuration.TimeDependenceJudgments != null)
-		{
-			configuration.TimeDependenceJudgments = configuration.TimeDependenceJudgments.OrderByDescending(x => x.Threshold).ToList();
-			if (!ValidateTimeDependenceJudgmentSegment(configuration.TimeDependenceJudgments))
-			{
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	private static bool ValidateJudgments(HsvConfigModel configuration)
-	{
-		configuration.Judgments = configuration.Judgments.OrderByDescending(x => x.Threshold).ToList();
-		var prevJudgment = configuration.Judgments[0];
-		if (prevJudgment.Fade)
-		{
-			prevJudgment = new()
-			{
-				Color = prevJudgment.Color,
-				Fade = false,
-				Text = prevJudgment.Text,
-				Threshold = prevJudgment.Threshold,
-			};
-		}
-
-		if (!ValidateJudgmentColor(prevJudgment))
-		{
-			Plugin.Log.Warn($"Judgment entry for threshold {prevJudgment.Threshold} has invalid color");
-			return false;
-		}
-
-		if (configuration.Judgments.Count > 1)
-		{
-			for (var i = 1; i < configuration.Judgments.Count; i++)
-			{
-				var currentJudgment = configuration.Judgments[i];
-				if (prevJudgment.Threshold != currentJudgment.Threshold)
-				{
-					if (!ValidateJudgmentColor(currentJudgment))
-					{
-						Plugin.Log.Warn($"Judgment entry for threshold {currentJudgment.Threshold} has invalid color");
-						return false;
-					}
-
-					prevJudgment = currentJudgment;
-					continue;
-				}
-
-				Plugin.Log.Warn($"Duplicate entry found for threshold {currentJudgment.Threshold}");
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	private static bool ValidateJudgmentColor(NormalJudgment judgment)
-	{
-		if (judgment.Color.Count != 4)
-		{
-			Plugin.Log.Warn($"Judgment for threshold {judgment.Threshold} has invalid color. Make sure to include exactly 4 numbers for each judgment's color!");
-			return false;
-		}
-
-		if (judgment.Color.All(x => x >= 0f))
-		{
-			return true;
-		}
-
-		Plugin.Log.Warn($"Judgment for threshold {judgment.Threshold} has invalid color. Make sure to include exactly 4 numbers that are greater or equal than 0 (and preferably smaller or equal than 1) for each judgment's color!");
-		return false;
-	}
-
-	private static bool ValidateJudgmentSegment(List<JudgmentSegment> segments)
-	{
-		if (segments.Count <= 1)
-		{
-			return true;
-		}
-
-		var prevJudgmentSegment = segments.First();
-		for (var i = 1; i < segments.Count; i++)
-		{
-			var currentJudgment = segments[i];
-			if (prevJudgmentSegment.Threshold != currentJudgment.Threshold)
-			{
-				prevJudgmentSegment = currentJudgment;
-				continue;
-			}
-
-			Plugin.Log.Warn($"Duplicate entry found for threshold {currentJudgment.Threshold}");
-			return false;
-		}
-
-		return true;
-	}
-
-	private static bool ValidateTimeDependenceJudgmentSegment(List<TimeDependenceJudgmentSegment> segments)
-	{
-		if (segments.Count <= 1)
-		{
-			return true;
-		}
-
-		var prevJudgmentSegment = segments.First();
-		for (var i = 1; i < segments.Count; i++)
-		{
-			var currentJudgment = segments[i];
-			if (prevJudgmentSegment.Threshold - currentJudgment.Threshold > double.Epsilon)
-			{
-				prevJudgmentSegment = currentJudgment;
-				continue;
-			}
-
-			Plugin.Log.Warn($"Duplicate entry found for threshold {currentJudgment.Threshold}");
-			return false;
-		}
-
-		return true;
+		return Validations.All(validation => validation.IsValid(configuration));
 	}
 }

--- a/HitScoreVisualizer/Utilities/Extensions/HsvConfigValidation.cs
+++ b/HitScoreVisualizer/Utilities/Extensions/HsvConfigValidation.cs
@@ -9,13 +9,16 @@ internal static class HsvConfigValidation
 {
 	private static IConfigValidation[] Validations { get; } =
 	[
-		new TimeDependenceDecimalValidation(),
 		new JudgmentsValidation(config => config.Judgments),
 		new JudgmentsValidation(config => config.ChainHeadJudgments),
+		new ChainLinkDisplayValidation(),
 		new JudgmentSegmentsValidation(config => config.BeforeCutAngleJudgments),
 		new JudgmentSegmentsValidation(config => config.AccuracyJudgments),
 		new JudgmentSegmentsValidation(config => config.AfterCutAngleJudgments),
-		new TimeDependenceJudgmentsValidation()
+		new TimeDependenceDecimalValidation(),
+		new TimeDependenceJudgmentsValidation(),
+		new BadCutDisplaysValidation(),
+		new MissDisplaysValidation()
 	];
 
 	public static bool Validate(this HsvConfigModel configuration)

--- a/HitScoreVisualizer/Utilities/Extensions/NoteExtensions.cs
+++ b/HitScoreVisualizer/Utilities/Extensions/NoteExtensions.cs
@@ -1,0 +1,14 @@
+namespace HitScoreVisualizer.Utilities.Extensions;
+
+internal static class NoteExtensions
+{
+	public static bool IsBomb(this NoteController noteController)
+	{
+		return noteController.noteData.colorType == ColorType.None;
+	}
+
+	public static bool IsBadCut(this NoteCutInfo noteCutInfo)
+	{
+		return !noteCutInfo.allIsOK;
+	}
+}

--- a/HitScoreVisualizer/Utilities/Services/ConfigLoader.cs
+++ b/HitScoreVisualizer/Utilities/Services/ConfigLoader.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;

--- a/HitScoreVisualizer/Utilities/Services/ConfigLoader.cs
+++ b/HitScoreVisualizer/Utilities/Services/ConfigLoader.cs
@@ -7,6 +7,7 @@ using HitScoreVisualizer.Utilities.Extensions;
 using HitScoreVisualizer.Utilities.Json;
 using IPA.Utilities;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Zenject;
 
 namespace HitScoreVisualizer.Utilities.Services;
@@ -22,7 +23,7 @@ public class ConfigLoader : IInitializable
 		DefaultValueHandling = DefaultValueHandling.Include,
 		NullValueHandling = NullValueHandling.Ignore,
 		Formatting = Formatting.Indented,
-		Converters = [ new Vector3Converter() ],
+		Converters = [ new Vector3Converter(), new StringEnumConverter() ],
 		ContractResolver = new HsvConfigContractResolver()
 	};
 

--- a/HitScoreVisualizer/Utilities/Services/ConfigLoader.cs
+++ b/HitScoreVisualizer/Utilities/Services/ConfigLoader.cs
@@ -73,7 +73,7 @@ public class ConfigLoader : IInitializable
 			await SaveConfig(configInfo);
 		}
 
-		if (configInfo.Config != null && configInfo.Config.Validate())
+		if (configInfo is { Config: not null, State: ConfigState.Compatible })
 		{
 			Plugin.Log.Info($"Selecting config {configInfo.ConfigName}");
 			pluginConfig.SelectedConfig = configInfo;

--- a/HitScoreVisualizer/Utilities/Services/ConfigMigrator.cs
+++ b/HitScoreVisualizer/Utilities/Services/ConfigMigrator.cs
@@ -1,8 +1,7 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using HitScoreVisualizer.Models;
+using HitScoreVisualizer.Models.ConfigMigrations;
 using HitScoreVisualizer.Utilities.Extensions;
 using Version = Hive.Versioning.Version;
 

--- a/HitScoreVisualizer/Utilities/Services/JudgmentService.cs
+++ b/HitScoreVisualizer/Utilities/Services/JudgmentService.cs
@@ -9,14 +9,12 @@ namespace HitScoreVisualizer.Utilities.Services;
 [UsedImplicitly]
 internal class JudgmentService
 {
-	private readonly PluginConfig pluginConfig;
+	private readonly HsvConfigModel config;
 
-	private JudgmentService(PluginConfig pluginConfig)
+	public JudgmentService(HsvConfigModel config)
 	{
-		this.pluginConfig = pluginConfig;
+		this.config = config;
 	}
-
-	private HsvConfigModel Config => pluginConfig.SelectedConfig?.Config ?? HsvConfigModel.Default;
 
 	public (string hitScoreText, Color hitScoreColor) Judge(IReadonlyCutScoreBuffer cutScoreBuffer, bool assumeMaxPostSwing)
 	{
@@ -41,19 +39,18 @@ internal class JudgmentService
 	{
 		var judgment = NormalJudgment.Default;
 		var fadeJudgment = NormalJudgment.Default;
-		Config.Judgments ??= [judgment];
 
-		for (var i = 0; i < Config.Judgments.Count; i++)
+		for (var i = 0; i < config.Judgments.Count; i++)
 		{
-			if (Config.Judgments[i].Threshold > totalCutScore)
+			if (config.Judgments[i].Threshold > totalCutScore)
 			{
 				continue;
 			}
 
-			judgment = Config.Judgments[i];
+			judgment = config.Judgments[i];
 			if (i > 0)
 			{
-				fadeJudgment = Config.Judgments[i - 1];
+				fadeJudgment = config.Judgments[i - 1];
 			}
 			break;
 		}
@@ -75,19 +72,18 @@ internal class JudgmentService
 	{
 		var judgment = ChainHeadJudgment.Default;
 		var fadeJudgment = ChainHeadJudgment.Default;
-		Config.ChainHeadJudgments ??= [judgment];
 
-		for (var i = 0; i < Config.ChainHeadJudgments.Count; i++)
+		for (var i = 0; i < config.ChainHeadJudgments.Count; i++)
 		{
-			if (Config.ChainHeadJudgments[i].Threshold > totalCutScore)
+			if (config.ChainHeadJudgments[i].Threshold > totalCutScore)
 			{
 				continue;
 			}
 
-			judgment = Config.ChainHeadJudgments[i];
+			judgment = config.ChainHeadJudgments[i];
 			if (i > 0)
 			{
-				fadeJudgment = Config.ChainHeadJudgments[i - 1];
+				fadeJudgment = config.ChainHeadJudgments[i - 1];
 			}
 			break;
 		}
@@ -104,7 +100,7 @@ internal class JudgmentService
 	private (string, Color) GetChainSegmentDisplay(int totalCutScore, int beforeCutScore,
 		int centerCutScore, int afterCutScore, int maxPossibleScore, NoteCutInfo noteCutInfo)
 	{
-		var chainLinkDisplay = Config.ChainLinkDisplay ?? ChainLinkDisplay.Default;
+		var chainLinkDisplay = config.ChainLinkDisplay ?? ChainLinkDisplay.Default;
 		var text = FormatJudgmentTextByMode(chainLinkDisplay.Text, totalCutScore, beforeCutScore, centerCutScore, afterCutScore, maxPossibleScore, noteCutInfo);
 		return (text, chainLinkDisplay.Color.ToColor());
 	}
@@ -112,7 +108,7 @@ internal class JudgmentService
 	private string FormatJudgmentTextByMode(string unformattedText, int totalCutScore, int beforeCutScore,
 		int centerCutScore, int afterCutScore, int maxPossibleScore, NoteCutInfo noteCutInfo)
 	{
-		return Config.DisplayMode switch
+		return config.DisplayMode switch
 		{
 			"format" => FormatJudgmentText(unformattedText, totalCutScore, beforeCutScore, centerCutScore, afterCutScore, maxPossibleScore, noteCutInfo),
 			"textOnly" => unformattedText,
@@ -146,11 +142,11 @@ internal class JudgmentService
 				'b' => beforeCutScore,
 				'c' => centerCutScore,
 				'a' => afterCutScore,
-				't' => (timeDependence * Mathf.Pow(10, Config.TimeDependenceDecimalOffset)).ToString($"n{Config.TimeDependenceDecimalPrecision}"),
-				'B' => Config.BeforeCutAngleJudgments.JudgeSegment(beforeCutScore),
-				'C' => Config.AccuracyJudgments.JudgeSegment(centerCutScore),
-				'A' => Config.AfterCutAngleJudgments.JudgeSegment(afterCutScore),
-				'T' => Config.TimeDependenceJudgments.JudgeTimeDependenceSegment(timeDependence, Config.TimeDependenceDecimalOffset, Config.TimeDependenceDecimalPrecision),
+				't' => (timeDependence * Mathf.Pow(10, config.TimeDependenceDecimalOffset)).ToString($"n{config.TimeDependenceDecimalPrecision}"),
+				'B' => config.BeforeCutAngleJudgments.JudgeSegment(beforeCutScore),
+				'C' => config.AccuracyJudgments.JudgeSegment(centerCutScore),
+				'A' => config.AfterCutAngleJudgments.JudgeSegment(afterCutScore),
+				'T' => config.TimeDependenceJudgments.JudgeTimeDependenceSegment(timeDependence, config.TimeDependenceDecimalOffset, config.TimeDependenceDecimalPrecision),
 				'd' => noteCutInfo.CalculateOffDirection().ToFormattedDirection(),
 				's' => totalCutScore,
 				'p' => $"{(double) totalCutScore / maxPossibleScore * 100:0}",

--- a/HitScoreVisualizer/Utilities/Services/PluginDirectories.cs
+++ b/HitScoreVisualizer/Utilities/Services/PluginDirectories.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using IPA.Utilities;
-using Zenject;
 
 namespace HitScoreVisualizer.Utilities.Services;
 


### PR DESCRIPTION
- Added customization for miss and bad cut effects with custom text

```json
"badCutDisplays": [
	{
		"text": "A Cut Of The Bad Variety",
		"color": [1.0, 0.7, 0.7, 1.0]
	}
],
"missDisplays": [
	{
		"text": "You Should Work On Your Aim",
		"color": [0.6, 1.0, 0.7, 1.0]
	}
]
```

- Miss and bad cut effects will be randomized by default unless you specify `randomizeBadCutDisplays` and `randomizeMissDisplays`

```json
"randomizeBadCutDisplays": false,
"randomizeMissDisplays": false
```

- For bad cuts, you can specify which types of bad cuts the display will show for. The options are `WrongDirection`, `WrongColor`, and `Bomb`. Not specifying a type will make the display show for all
types of bad cuts

```json
"badCutDisplays": [
	{
		"text": "<size=600%>BOOM",
		"type": "Bomb",
		"color": [1.0, 1.0, 1.0, 1.0]
	}
]
```