### PR TITLE
New migrations

### DIFF
--- a/HitScoreVisualizer/Models/ConfigMigrations/ConfigMigration340.cs
+++ b/HitScoreVisualizer/Models/ConfigMigrations/ConfigMigration340.cs
@@ -1,0 +1,16 @@
+using Hive.Versioning;
+
+namespace HitScoreVisualizer.Models.ConfigMigrations;
+
+internal class ConfigMigration340 : IHsvConfigMigration
+{
+	public Version Version { get; } = new(3, 4, 0);
+
+	public void Migrate(HsvConfigModel config)
+	{
+		if (config.ChainHeadJudgments is null or [])
+		{
+			config.ChainHeadJudgments = [ChainHeadJudgment.Default];
+		}
+	}
+}

--- a/HitScoreVisualizer/Models/ConfigMigrations/ConfigMigration360.cs
+++ b/HitScoreVisualizer/Models/ConfigMigrations/ConfigMigration360.cs
@@ -1,0 +1,15 @@
+using System.Linq;
+using Hive.Versioning;
+
+namespace HitScoreVisualizer.Models.ConfigMigrations;
+
+internal class ConfigMigration360 : IHsvConfigMigration
+{
+	public Version Version { get; } = new(3, 6, 0);
+
+	public void Migrate(HsvConfigModel config)
+	{
+		config.Judgments = config.Judgments.OrderByDescending(x => x.Threshold).ToList();
+		config.ChainHeadJudgments = config.ChainHeadJudgments.OrderByDescending(x => x.Threshold).ToList();
+	}
+}

--- a/HitScoreVisualizer/Utilities/Services/ConfigMigrator.cs
+++ b/HitScoreVisualizer/Utilities/Services/ConfigMigrator.cs
@@ -16,7 +16,8 @@ internal class ConfigMigrator
 		new ConfigMigration210(),
 		new ConfigMigration223(),
 		new ConfigMigration320(),
-		new ConfigMigration340()
+		new ConfigMigration340(),
+		new ConfigMigration360()
 	];
 
 	private readonly Version minimumMigratableVersion;

--- a/HitScoreVisualizer/Utilities/Services/ConfigMigrator.cs
+++ b/HitScoreVisualizer/Utilities/Services/ConfigMigrator.cs
@@ -15,7 +15,8 @@ internal class ConfigMigrator
 		new ConfigMigration200(),
 		new ConfigMigration210(),
 		new ConfigMigration223(),
-		new ConfigMigration320()
+		new ConfigMigration320(),
+		new ConfigMigration340()
 	];
 
 	private readonly Version minimumMigratableVersion;


### PR DESCRIPTION
- Migration for 3.4.0 to add chain head judgment
- Migration for 3.6.0 to make sure the ordered judgments rule is enforced