### PR TITLE
Fix bug in calculation of the closest normal direction.

### DIFF
--- a/HitScoreVisualizer/Utilities/Extensions/DirectionConversion.cs
+++ b/HitScoreVisualizer/Utilities/Extensions/DirectionConversion.cs
@@ -57,7 +57,7 @@ internal static class DirectionConversion
 			{
 				continue;
 			}
-			closestDot = dot;
+			closestDot = dotValue;
 			result = direction;
 		}
 


### PR DESCRIPTION
We compare absolute values, but then store the plain value as the current max. This breaks in the case where the closest off is a negative dot product, but is overridden by a subsequent, smaller positive dot product.

How did I find this? Well it apparently happened enough times in game for me to notice that the arrow was often pointing in the wrong direction.

(I've not tested this, but if you want me to let me know how)